### PR TITLE
Use primary key as customer ID

### DIFF
--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -72,7 +72,7 @@ trait PerformsCharges
             throw new LogicException('The value for "passthrough" always needs to be a an array.');
         }
 
-        $payload['passthrough']['customer_id'] = $this->getAuthIdentifier();
+        $payload['passthrough']['customer_id'] = $this->getKey();
 
         $payload['passthrough'] = json_encode($payload['passthrough']);
 


### PR DESCRIPTION
Hi @driesvints,

The billable model could be different from user, let's use the value of the model's primary key instead. Thoughts?

Thanks,