### PR TITLE
Prevent swapping during trial

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -436,7 +436,7 @@ class Subscription extends Model
     public function swap($plan, array $options = [])
     {
         if ($this->onTrial()) {
-            throw new LogicException('Cannot swap plans while on trial.');
+            throw new LogicException('Paddle does not allow swapping plans while on trial.');
         }
 
         if ($this->paused() || $this->pastDue()) {

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -435,6 +435,10 @@ class Subscription extends Model
      */
     public function swap($plan, array $options = [])
     {
+        if ($this->onTrial()) {
+            throw new LogicException('Cannot swap plans while on trial.');
+        }
+
         if ($this->paused() || $this->pastDue()) {
             throw new LogicException('Cannot swap plans for paused or past due subscriptions.');
         }

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -12,7 +12,7 @@ class SubscriptionsTest extends FeatureTestCase
     {
         $subscription = new Subscription(['trial_ends_at' => now()->addDay()]);
 
-        $this->expectExceptionObject(new LogicException('Cannot swap plans while on trial.'));
+        $this->expectExceptionObject(new LogicException('Paddle does not allow swapping plans while on trial.'));
 
         $subscription->swap(123);
     }

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -4,9 +4,19 @@ namespace Tests\Feature;
 
 use Carbon\Carbon;
 use Laravel\Paddle\Subscription;
+use LogicException;
 
 class SubscriptionsTest extends FeatureTestCase
 {
+    public function test_cannot_swap_while_on_trial()
+    {
+        $subscription = new Subscription(['trial_ends_at' => now()->addDay()]);
+
+        $this->expectExceptionObject(new LogicException('Cannot swap plans while on trial.'));
+
+        $subscription->swap(123);
+    }
+
     public function test_customers_can_perform_subscription_checks()
     {
         $billable = $this->createBillable();

--- a/tests/Unit/ProductPriceTest.php
+++ b/tests/Unit/ProductPriceTest.php
@@ -8,19 +8,19 @@ use PHPUnit\Framework\TestCase;
 
 class ProductPriceTest extends TestCase
 {
-    public function it_can_return_its_country()
+    public function test_it_can_return_its_country()
     {
         $product = $this->product();
 
-        $this->assertInstanceOf('BE', $product->customerCountry());
+        $this->assertSame('BE', $product->customerCountry());
     }
 
-    public function it_can_return_its_currency()
+    public function test_it_can_return_its_currency()
     {
         $currency = $this->product()->currency();
 
         $this->assertInstanceOf(Currency::class, $currency);
-        $this->assertInstanceOf('EUR', $currency->getCode());
+        $this->assertSame('EUR', $currency->getCode());
     }
 
     public function test_it_implements_arrayable_and_jsonable()

--- a/tests/Unit/TransactionTest.php
+++ b/tests/Unit/TransactionTest.php
@@ -31,7 +31,7 @@ class TransactionTest extends TestCase
         $this->assertSame($customer, $transaction->customer());
     }
 
-    public function it_can_return_its_currency()
+    public function test_it_can_return_its_currency()
     {
         $customer = new Customer(['paddle_id' => 1]);
         $transaction = new Transaction($customer, [
@@ -41,7 +41,7 @@ class TransactionTest extends TestCase
         $currency = $transaction->currency();
 
         $this->assertInstanceOf(Currency::class, $currency);
-        $this->assertInstanceOf('EUR', $currency->getCode());
+        $this->assertSame('EUR', $currency->getCode());
     }
 
     public function test_it_can_returns_its_receipt_url()


### PR DESCRIPTION
Unfortunately Paddle doesn't allows this so it's best to prevent the request from happening.

Also fixes some tests.