### PR TITLE
Call subscriptions as relation

### DIFF
--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -30,7 +30,7 @@ trait ManagesSubscriptions
             return new Collection;
         }
 
-        return $this->customer->subscriptions;
+        return $this->customer->subscriptions();
     }
 
     /**


### PR DESCRIPTION
Customer relation for subscriptions must be return collection.

You can not use scopes if subscriptions not Collection.
