### PR TITLE
Implement new prices

### DIFF
--- a/src/ProductPrice.php
+++ b/src/ProductPrice.php
@@ -67,6 +67,86 @@ class ProductPrice implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
+     * Get the initial price for the subscription plan with a coupon applied.
+     *
+     * @return \Laravel\Paddle\Price
+     */
+    public function initialPrice()
+    {
+        return $this->price();
+    }
+
+    /**
+     * Get the initial original listed price for the subscription plan.
+     *
+     * @return \Laravel\Paddle\Price
+     */
+    public function initialListPrice()
+    {
+        return $this->listPrice();
+    }
+
+    /**
+     * Get the recurring price for the subscription plan with a coupon applied.
+     *
+     * @return \Laravel\Paddle\Price
+     */
+    public function recurringPrice()
+    {
+        if (isset($this->product['subscription'])) {
+            return new Price($this->product['subscription']['price'], $this->currency());
+        }
+    }
+
+    /**
+     * Get the recurring original listed price for the subscription plan.
+     *
+     * @return \Laravel\Paddle\Price|null
+     */
+    public function recurringListPrice()
+    {
+        if (isset($this->product['subscription'])) {
+            return new Price($this->product['subscription']['list_price'], $this->currency());
+        }
+    }
+
+    /**
+     * Get the amount of trial days for the subscription plan.
+     *
+     * @return int|null
+     */
+    public function planTrialDays()
+    {
+        if (isset($this->product['subscription'])) {
+            return $this->product['subscription']['trial_days'];
+        }
+    }
+
+    /**
+     * Get the interval for the subscription plan.
+     *
+     * @return string|null
+     */
+    public function planInterval()
+    {
+        if (isset($this->product['subscription'])) {
+            return $this->product['subscription']['interval'];
+        }
+    }
+
+    /**
+     * Get the frequency for the subscription plan.
+     *
+     * @return int|null
+     */
+    public function planFrequency()
+    {
+        if (isset($this->product['subscription'])) {
+            return $this->product['subscription']['frequency'];
+        }
+    }
+
+    /**
      * Get the used currency for the transaction.
      *
      * @return \Money\Currency

--- a/tests/Unit/ProductPriceTest.php
+++ b/tests/Unit/ProductPriceTest.php
@@ -2,12 +2,44 @@
 
 namespace Tests\Unit;
 
+use Laravel\Paddle\Price;
 use Laravel\Paddle\ProductPrice;
 use Money\Currency;
 use PHPUnit\Framework\TestCase;
 
 class ProductPriceTest extends TestCase
 {
+    const DEFAULTS = [
+        'product_id' => 232,
+        'product_title' => 232,
+        'currency' => 'EUR',
+        'price' => [
+            'gross' => 12.45,
+            'net' => '6.25',
+            'tax' => 3.24,
+        ],
+        'list_price' => [
+            'gross' => 12.45,
+            'net' => '6.25',
+            'tax' => 3.24,
+        ],
+        'subscription' => [
+            'trial_days' => 5,
+            'interval' => 'monthly',
+            'frequency' => 1,
+            'price' => [
+                'gross' => 12.45,
+                'net' => '6.25',
+                'tax' => 3.24,
+            ],
+            'list_price' => [
+                'gross' => 12.45,
+                'net' => '6.25',
+                'tax' => 3.24,
+            ],
+        ],
+    ];
+
     public function test_it_can_return_its_country()
     {
         $product = $this->product();
@@ -23,14 +55,31 @@ class ProductPriceTest extends TestCase
         $this->assertSame('EUR', $currency->getCode());
     }
 
+    public function test_it_can_return_prices()
+    {
+        $product = $this->product();
+
+        $this->assertInstanceOf(Price::class, $product->price());
+        $this->assertInstanceOf(Price::class, $product->listPrice());
+        $this->assertInstanceOf(Price::class, $product->initialPrice());
+        $this->assertInstanceOf(Price::class, $product->initialListPrice());
+        $this->assertInstanceOf(Price::class, $product->recurringPrice());
+        $this->assertInstanceOf(Price::class, $product->recurringListPrice());
+    }
+
+    public function test_it_can_return_plan_info()
+    {
+        $product = $this->product();
+
+        $this->assertSame(5, $product->planTrialDays());
+        $this->assertSame('monthly', $product->planInterval());
+        $this->assertSame(1, $product->planFrequency());
+    }
+
     public function test_it_implements_arrayable_and_jsonable()
     {
         $product = $this->product();
-        $data = [
-            'product_id' => 232,
-            'product_title' => 232,
-            'currency' => 'EUR',
-        ];
+        $data = self::DEFAULTS;
 
         $this->assertSame($data, $product->toArray());
         $this->assertSame($data, $product->jsonSerialize());
@@ -45,10 +94,6 @@ class ProductPriceTest extends TestCase
      */
     private function product(array $product = [])
     {
-        return new ProductPrice('BE', array_merge([
-            'product_id' => 232,
-            'product_title' => 232,
-            'currency' => 'EUR',
-        ], $product));
+        return new ProductPrice('BE', array_merge(self::DEFAULTS, $product));
     }
 }


### PR DESCRIPTION
This PR adds some new methods for the prices api. Additional to the current `price` and `listPrice` method this PR introduces the following new ones:

- `initialPrice`: alias of `price` but better terminology for subscriptions plans
- `initialListPrice`: alias of `listPrice` but better terminology for subscriptions plans
- `recurringPrice`: the recurring amount each interval for subscription plans
- `recurringListPrice`: the originally listed amount each interval for subscription plans

This PR also adds some convenience methods to get information about subscription plans which can be used to display in UI:

- `planTrialDays`
- `planInterval`
- `planFrequency`