### PR TITLE
Use endpoint for card info

### DIFF
--- a/database/migrations/2019_05_03_000002_create_subscriptions_table.php
+++ b/database/migrations/2019_05_03_000002_create_subscriptions_table.php
@@ -16,8 +16,6 @@ class CreateSubscriptionsTable extends Migration
         Schema::create('subscriptions', function (Blueprint $table) {
             $table->id();
             $table->unsignedBigInteger('customer_id');
-            $table->string('card_brand')->nullable();
-            $table->string('card_last_four', 4)->nullable();
             $table->string('name');
             $table->integer('paddle_id');
             $table->string('paddle_status');

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -105,8 +105,6 @@ class WebhookController extends Controller
             'quantity' => $payload['quantity'],
             'trial_ends_at' => $trialEndsAt,
         ]);
-
-        $subscription->syncPaymentInformation();
     }
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -673,24 +673,22 @@ class Subscription extends Model
     }
 
     /**
-     * Sync the payment information from Paddle with the subscription.
+     * Get the card brand from the subscription.
      *
-     * @return $this
+     * @return string
      */
-    public function syncPaymentInformation()
+    public function cardBrand()
     {
-        $info = $this->paddleInfo()['payment_information'];
+        return (string) $this->paddleInfo()['card_type'];
+    }
 
-        if ($info['payment_method'] === 'card') {
-            $this->card_brand = $info['card_type'];
-            $this->card_last_four = $info['last_four_digits'];
-        } elseif ($info['payment_method'] === 'paypal') {
-            $this->card_brand = 'paypal';
-            $this->card_last_four = '';
-        }
-
-        $this->save();
-
-        return $this;
+    /**
+     * Get the last four digits from the subscription if it's a credit card.
+     *
+     * @return string
+     */
+    public function cardLastFour()
+    {
+        return (string) $this->paddleInfo()['last_four_digits'];
     }
 }


### PR DESCRIPTION
Paddle doesn't has a webhook to inform us when the payment information was updated so we'll have to read the info directly from the endpoint.