### PR TITLE
Allow to create empty customer

### DIFF
--- a/database/migrations/2019_05_03_000001_create_customers_table.php
+++ b/database/migrations/2019_05_03_000001_create_customers_table.php
@@ -17,12 +17,12 @@ class CreateCustomersTable extends Migration
             $table->id();
             $table->unsignedBigInteger('billable_id');
             $table->string('billable_type');
-            $table->string('paddle_id')->unique();
-            $table->string('paddle_email')->unique();
+            $table->string('paddle_id')->nullable()->unique();
+            $table->string('paddle_email')->nullable()->unique();
             $table->timestamp('trial_ends_at')->nullable();
             $table->timestamps();
 
-            $table->index(['billable_id', 'billable_type']);
+            $table->unique(['billable_id', 'billable_type']);
         });
     }
 

--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -8,6 +8,17 @@ use Laravel\Paddle\Customer;
 trait ManagesCustomer
 {
     /**
+     * Create a customer record for the billable model.
+     *
+     * @param  array  $attributes
+     * @return \Laravel\Paddle\Customer
+     */
+    public function createAsCustomer(array $attributes = [])
+    {
+        return $this->customer()->create($attributes);
+    }
+
+    /**
      * Get the customer related to the billable model.
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphOne

--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -73,7 +73,11 @@ trait ManagesSubscriptions
      */
     public function onGenericTrial()
     {
-        return optional($this->customer)->onGenericTrial();
+        if (is_null($this->customer)) {
+            return false;
+        }
+
+        return $this->customer->onGenericTrial();
     }
 
     /**
@@ -120,6 +124,10 @@ trait ManagesSubscriptions
      */
     public function onPlan($plan)
     {
+        if (is_null($this->customer)) {
+            return false;
+        }
+
         return $this->customer->onPlan($plan);
     }
 }

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -70,6 +70,7 @@ class WebhookController extends Controller
         Customer::firstOrCreate([
             'billable_id' => $passthrough['billable_id'],
             'billable_type' => $passthrough['billable_type'],
+        ], [
             'paddle_id' => $response['user']['user_id'],
             'paddle_email' => $payload['email'],
         ]);
@@ -89,6 +90,7 @@ class WebhookController extends Controller
         $customer = Customer::firstOrCreate([
             'billable_id' => $passthrough['billable_id'],
             'billable_type' => $passthrough['billable_type'],
+        ], [
             'paddle_id' => $payload['user_id'],
             'paddle_email' => $payload['email'],
         ]);
@@ -97,7 +99,7 @@ class WebhookController extends Controller
             ? Carbon::createFromFormat('Y-m-d', $payload['next_bill_date'], 'UTC')->startOfDay()
             : null;
 
-        $subscription = $customer->subscriptions()->create([
+        $customer->subscriptions()->create([
             'name' => $passthrough['subscription_name'],
             'paddle_id' => $payload['subscription_id'],
             'paddle_plan' => $payload['subscription_plan_id'],

--- a/tests/Feature/CustomerTest.php
+++ b/tests/Feature/CustomerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature;
+
+class CustomerTest extends FeatureTestCase
+{
+    public function test_billable_models_can_create_a_customer_record()
+    {
+        $user = $this->createUser();
+
+        $customer = $user->createAsCustomer(['trial_ends_at' => $trialEndsAt = now()->addDays(15)]);
+
+        $this->assertSame($trialEndsAt->timestamp, $customer->trial_ends_at->timestamp);
+        $this->assertTrue($user->onGenericTrial());
+    }
+
+    public function test_billable_models_without_having_a_customer_record_can_still_use_some_methods()
+    {
+        $user = $this->createUser();
+
+        $this->assertFalse($user->onTrial());
+        $this->assertFalse($user->onGenericTrial());
+        $this->assertFalse($user->onPlan(123));
+        $this->assertFalse($user->subscribed());
+        $this->assertFalse($user->subscribedToPlan(123));
+        $this->assertEmpty($user->transactions());
+        $this->assertEmpty($user->subscriptions());
+        $this->assertNull($user->subscription());
+    }
+}

--- a/tests/Feature/FeatureTestCase.php
+++ b/tests/Feature/FeatureTestCase.php
@@ -19,7 +19,7 @@ abstract class FeatureTestCase extends TestCase
 
     protected function createBillable($description = 'taylor', $options = []): User
     {
-        $user = User::create([
+        $user =$this->createUser([
             'email' => "{$description}@paddle-test.com",
             'name' => 'Taylor Otwell',
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi',
@@ -31,6 +31,15 @@ abstract class FeatureTestCase extends TestCase
         ], $options));
 
         return $user;
+    }
+
+    protected function createUser($description = 'taylor', $options = []): User
+    {
+        return User::create(array_merge([
+            'email' => "{$description}@paddle-test.com",
+            'name' => 'Taylor Otwell',
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi',
+        ], $options));
     }
 
     protected function getPackageProviders($app)

--- a/tests/Feature/FeatureTestCase.php
+++ b/tests/Feature/FeatureTestCase.php
@@ -17,13 +17,9 @@ abstract class FeatureTestCase extends TestCase
         $this->artisan('migrate')->run();
     }
 
-    protected function createBillable($description = 'taylor', $options = []): User
+    protected function createBillable($description = 'taylor', array $options = []): User
     {
-        $user =$this->createUser([
-            'email' => "{$description}@paddle-test.com",
-            'name' => 'Taylor Otwell',
-            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi',
-        ]);
+        $user =$this->createUser($description);
 
         $user->customer()->create(array_merge([
             'paddle_id' => $_SERVER['PADDLE_TEST_CUSTOMER_ID'],
@@ -33,7 +29,7 @@ abstract class FeatureTestCase extends TestCase
         return $user;
     }
 
-    protected function createUser($description = 'taylor', $options = []): User
+    protected function createUser($description = 'taylor', array $options = []): User
     {
         return User::create(array_merge([
             'email' => "{$description}@paddle-test.com",


### PR DESCRIPTION
This PR will allow people to create customer records in advance of any subscriptions or one-time product charges being made. This will allow them to use the trial without card up front feature. See https://github.com/laravel/cashier-paddle/pull/18#discussion_r445776921

Ping @stefanzweifel