### PR TITLE
Refactor to polymorphic subscriptions

### DIFF
--- a/database/migrations/2019_05_03_000002_create_subscriptions_table.php
+++ b/database/migrations/2019_05_03_000002_create_subscriptions_table.php
@@ -15,9 +15,10 @@ class CreateSubscriptionsTable extends Migration
     {
         Schema::create('subscriptions', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('customer_id');
+            $table->unsignedBigInteger('billable_id');
+            $table->string('billable_type');
             $table->string('name');
-            $table->integer('paddle_id');
+            $table->integer('paddle_id')->unique();
             $table->string('paddle_status');
             $table->integer('paddle_plan');
             $table->integer('quantity');
@@ -26,7 +27,7 @@ class CreateSubscriptionsTable extends Migration
             $table->timestamp('ends_at')->nullable();
             $table->timestamps();
 
-            $table->unique(['customer_id', 'paddle_id']);
+            $table->index(['billable_id', 'billable_type']);
         });
     }
 

--- a/src/Customer.php
+++ b/src/Customer.php
@@ -4,6 +4,9 @@ namespace Laravel\Paddle;
 
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @property \Laravel\Paddle\Billable $billable
+ */
 class Customer extends Model
 {
     /**
@@ -34,43 +37,6 @@ class Customer extends Model
     }
 
     /**
-     * Get all of the subscriptions for the Customer model.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
-     */
-    public function subscriptions()
-    {
-        return $this->hasMany(Subscription::class)->orderByDesc('created_at');
-    }
-
-    /**
-     * Get a subscription instance by name.
-     *
-     * @param  string  $name
-     * @return \Laravel\Paddle\Subscription|null
-     */
-    public function subscription($name = 'default')
-    {
-        return $this->subscriptions()->where('name', $name)->first();
-    }
-
-    /**
-     * Determine if the entity has a valid subscription on the given plan.
-     *
-     * @param  int  $plan
-     * @return bool
-     */
-    public function onPlan($plan)
-    {
-        return ! is_null($this->subscriptions()
-            ->where('paddle_plan', $plan)
-            ->get()
-            ->first(function (Subscription $subscription) use ($plan) {
-                return $subscription->valid();
-            }));
-    }
-
-    /**
      * Determine if the Paddle model is on a "generic" trial at the model level.
      *
      * @return bool
@@ -78,16 +44,5 @@ class Customer extends Model
     public function onGenericTrial()
     {
         return $this->trial_ends_at && $this->trial_ends_at->isFuture();
-    }
-
-    /**
-     * Get the default Paddle API options for the current Billable model.
-     *
-     * @param  array  $options
-     * @return array
-     */
-    public function paddleOptions(array $options = [])
-    {
-        return $this->billable->paddleOptions($options);
     }
 }

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -99,7 +99,9 @@ class WebhookController extends Controller
             ? Carbon::createFromFormat('Y-m-d', $payload['next_bill_date'], 'UTC')->startOfDay()
             : null;
 
-        $customer->subscriptions()->create([
+        $customer->billable->subscriptions()->create([
+            'billable_id' => $passthrough['billable_id'],
+            'billable_type' => $passthrough['billable_type'],
             'name' => $passthrough['subscription_name'],
             'paddle_id' => $payload['subscription_id'],
             'paddle_plan' => $payload['subscription_plan_id'],

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -128,7 +128,7 @@ class Transaction implements Arrayable, Jsonable, JsonSerializable
     public function subscription()
     {
         if ($this->isSubscription()) {
-            return $this->customer->subscriptions()
+            return $this->customer->billable->subscriptions()
                 ->where('paddle_id', $this->transaction['subscription']['subscription_id'])
                 ->first();
         }

--- a/tests/Feature/CustomerTest.php
+++ b/tests/Feature/CustomerTest.php
@@ -24,7 +24,7 @@ class CustomerTest extends FeatureTestCase
         $this->assertFalse($user->subscribed());
         $this->assertFalse($user->subscribedToPlan(123));
         $this->assertEmpty($user->transactions());
-        $this->assertEmpty($user->subscriptions());
+        $this->assertEmpty($user->subscriptions);
         $this->assertNull($user->subscription());
     }
 }

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -21,7 +21,7 @@ class SubscriptionsTest extends FeatureTestCase
     {
         $billable = $this->createBillable();
 
-        $subscription = $billable->customer->subscriptions()->create([
+        $subscription = $billable->subscriptions()->create([
             'name' => 'main',
             'paddle_id' => 244,
             'paddle_plan' => 2323,
@@ -61,7 +61,7 @@ class SubscriptionsTest extends FeatureTestCase
     {
         $billable = $this->createBillable('taylor');
 
-        $subscription = $billable->customer->subscriptions()->create([
+        $subscription = $billable->subscriptions()->create([
             'name' => 'main',
             'paddle_id' => 244,
             'paddle_plan' => 2323,
@@ -95,7 +95,7 @@ class SubscriptionsTest extends FeatureTestCase
     {
         $billable = $this->createBillable('taylor');
 
-        $subscription = $billable->customer->subscriptions()->create([
+        $subscription = $billable->subscriptions()->create([
             'name' => 'main',
             'paddle_id' => 244,
             'paddle_plan' => 2323,
@@ -118,7 +118,7 @@ class SubscriptionsTest extends FeatureTestCase
     {
         $billable = $this->createBillable('taylor');
 
-        $subscription = $billable->customer->subscriptions()->create([
+        $subscription = $billable->subscriptions()->create([
             'name' => 'main',
             'paddle_id' => 244,
             'paddle_plan' => 2323,
@@ -141,7 +141,7 @@ class SubscriptionsTest extends FeatureTestCase
     {
         $billable = $this->createBillable('taylor');
 
-        $subscription = $billable->customer->subscriptions()->create([
+        $subscription = $billable->subscriptions()->create([
             'name' => 'main',
             'paddle_id' => 244,
             'paddle_plan' => 2323,
@@ -163,7 +163,7 @@ class SubscriptionsTest extends FeatureTestCase
     {
         $billable = $this->createBillable('taylor');
 
-        $subscription = $billable->customer->subscriptions()->create([
+        $subscription = $billable->subscriptions()->create([
             'name' => 'main',
             'paddle_id' => 244,
             'paddle_plan' => 2323,

--- a/tests/Feature/TransactionsTest.php
+++ b/tests/Feature/TransactionsTest.php
@@ -46,7 +46,7 @@ class TransactionsTest extends FeatureTestCase
     public function test_it_can_returns_its_subscription()
     {
         $billable = $this->createBillable();
-        $subscription = $billable->customer->subscriptions()->create([
+        $subscription = $billable->subscriptions()->create([
             'name' => 'default',
             'paddle_id' => 244,
             'paddle_plan' => 2323,


### PR DESCRIPTION
This will make it easier to access subscriptions from the billable model. All subscription based methods are now removed from the `Customer` model. They can always be accessed through the billable model.

Now you can apply scopes on subscriptions from the billable model:

```php
$user->subscriptions()->active()->get();
```

In an ideal later scenario we'd have a custom relationship so accessing the subscriptions can be done through the `Customer` model and the database scheme would be safer (direct relationships) and simpler. But for now this is a good intermediate solution.