### PR TITLE
Update possible existing Customer with paddle_id

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -67,7 +67,7 @@ class WebhookController extends Controller
             Cashier::paddleOptions()
         )['response'][0];
 
-        Customer::firstOrCreate([
+        Customer::updateOrCreate([
             'billable_id' => $passthrough['billable_id'],
             'billable_type' => $passthrough['billable_type'],
         ], [
@@ -87,7 +87,7 @@ class WebhookController extends Controller
         $passthrough = json_decode($payload['passthrough'], true);
 
         /** @var \Laravel\Paddle\Customer $customer */
-        $customer = Customer::firstOrCreate([
+        $customer = Customer::updateOrCreate([
             'billable_id' => $passthrough['billable_id'],
             'billable_type' => $passthrough['billable_type'],
         ], [

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -32,9 +32,80 @@ class WebhooksTest extends FeatureTestCase
         ]);
     }
 
+    /** @test */
+    public function test_it_can_handle_a_payment_succeeded_event_when_billable_already_exists()
+    {
+        if (! isset($_SERVER['PADDLE_TEST_CHECKOUT'])) {
+            $this->markTestSkipped('Checkout identifier not configured');
+        }
+
+        $user = $this->createUser();
+        $user->customer()->create([
+            'trial_ends_at' => now('UTC')->addDays(5)
+        ]);
+
+        $this->postJson('paddle/webhook', [
+            'alert_name' => 'payment_succeeded',
+            'checkout_id' => $_SERVER['PADDLE_TEST_CHECKOUT'],
+            'email' => $user->paddleEmail(),
+            'passthrough' => json_encode([
+                'billable_id' => $user->id,
+                'billable_type' => $user->getMorphClass(),
+            ]),
+        ])->assertOk();
+
+        $this->assertDatabaseHas('customers', [
+            'billable_id' => $user->id,
+            'billable_type' => $user->getMorphClass(),
+            'paddle_email' => $user->paddleEmail(),
+        ]);
+    }
+
     public function test_it_can_handle_a_subscription_created_event()
     {
         $user = $this->createUser();
+
+        $this->postJson('paddle/webhook', [
+            'alert_name' => 'subscription_created',
+            'user_id' => 'foo',
+            'email' => $user->paddleEmail(),
+            'passthrough' => json_encode([
+                'billable_id' => $user->id,
+                'billable_type' => $user->getMorphClass(),
+                'subscription_name' => 'main',
+            ]),
+            'quantity' => 1,
+            'status' => Subscription::STATUS_ACTIVE,
+            'subscription_id' => 'bar',
+            'subscription_plan_id' => 1234,
+        ])->assertOk();
+
+        $this->assertDatabaseHas('customers', [
+            'billable_id' => $user->id,
+            'billable_type' => $user->getMorphClass(),
+            'paddle_id' => 'foo',
+            'paddle_email' => $user->paddleEmail(),
+        ]);
+
+        $this->assertDatabaseHas('subscriptions', [
+            'billable_id' => $user->id,
+            'billable_type' => $user->getMorphClass(),
+            'name' => 'main',
+            'paddle_id' => 'bar',
+            'paddle_plan' => 1234,
+            'paddle_status' => Subscription::STATUS_ACTIVE,
+            'quantity' => 1,
+            'trial_ends_at' => null,
+        ]);
+    }
+
+    /** @test */
+    public function test_it_can_handle_a_subscription_created_event_if_billable_already_exists()
+    {
+        $user = $this->createUser();
+        $user->customer()->create([
+            'trial_ends_at' => now('UTC')->addDays(5)
+        ]);
 
         $this->postJson('paddle/webhook', [
             'alert_name' => 'subscription_created',


### PR DESCRIPTION
The current `master`-version of the package doesn't update an existing customer with `paddle_id` and `paddle_email` when a user subscribes to a plan.

My app is responsible for trial-periods and creates a new customer during registration. Subscribing to a plan in this scenario would not add the `paddle_id` to the customer which in turn breaks `$user->transactions()`.

```php
$user->createAsCustomer([
    'trial_ends_at' => now('UTC')->addDays(14),
]);
```