### PR TITLE
Fix webhook controller

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -186,15 +186,9 @@ class WebhookController extends Controller
         }
 
         // Cancellation date...
-        if (isset($payload['cancellation_effective_date'])) {
-            if ($payload['cancellation_effective_date']) {
-                $subscription->ends_at = $subscription->onTrial()
-                    ? $subscription->trial_ends_at
-                    : Carbon::createFromFormat('Y-m-d', $payload['cancellation_effective_date'], 'UTC')->startOfDay();
-            } else {
-                $subscription->ends_at = null;
-            }
-        }
+        $subscription->ends_at = $subscription->onTrial()
+            ? $subscription->trial_ends_at
+            : Carbon::createFromFormat('Y-m-d', $payload['cancellation_effective_date'], 'UTC')->startOfDay();
 
         // Status...
         if (isset($payload['status'])) {

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -159,8 +159,8 @@ class WebhookController extends Controller
         }
 
         // Quantity...
-        if (isset($payload['quantity'])) {
-            $subscription->quantity = $payload['quantity'];
+        if (isset($payload['new_quantity'])) {
+            $subscription->quantity = $payload['new_quantity'];
         }
 
         // Paused...

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -250,7 +250,7 @@ class WebhooksTest extends FeatureTestCase
 
         $this->postJson('paddle/webhook', [
             'alert_name' => 'subscription_updated',
-            'quantity' => 3,
+            'new_quantity' => 3,
             'status' => Subscription::STATUS_PAUSED,
             'paused_from' => ($date = now('UTC')->addDays(5))->format('Y-m-d H:i:s'),
             'subscription_id' => 244,


### PR DESCRIPTION
Fixes a bug with a wrong referenced `quantity` parameter and removes the checks from the `cancellation_effective_date` parameter which is always set.

Fixes https://github.com/laravel/cashier-paddle/issues/41