### PR TITLE
Update URL will now be stored in the database

### DIFF
--- a/database/migrations/2019_05_03_000002_create_subscriptions_table.php
+++ b/database/migrations/2019_05_03_000002_create_subscriptions_table.php
@@ -22,6 +22,7 @@ class CreateSubscriptionsTable extends Migration
             $table->string('paddle_status');
             $table->integer('paddle_plan');
             $table->integer('quantity');
+            $table->string('update_url', 200);
             $table->timestamp('trial_ends_at')->nullable();
             $table->timestamp('paused_from')->nullable();
             $table->timestamp('ends_at')->nullable();

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -133,6 +133,7 @@ class WebhookController extends Controller
             'paddle_status' => $payload['status'],
             'quantity' => $payload['quantity'],
             'trial_ends_at' => $trialEndsAt,
+            'update_url' => $payload['update_url'],
         ]);
     }
 
@@ -168,6 +169,11 @@ class WebhookController extends Controller
             $subscription->paused_from = Carbon::createFromFormat('Y-m-d H:i:s', $payload['paused_from'], 'UTC');
         } else {
             $subscription->paused_from = null;
+        }
+
+        // Update url
+        if (isset($payload['update_url'])) {
+            $subscription->update_url = $payload['update_url'];
         }
 
         $subscription->save();

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -541,16 +541,6 @@ class Subscription extends Model
     }
 
     /**
-     * Get the Paddle update url.
-     *
-     * @return array
-     */
-    public function updateUrl()
-    {
-        return $this->paddleInfo()['update_url'];
-    }
-
-    /**
      * Cancel the subscription.
      *
      * @return $this

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -177,6 +177,7 @@ class WebhooksTest extends FeatureTestCase
             'status' => Subscription::STATUS_ACTIVE,
             'subscription_id' => 'bar',
             'subscription_plan_id' => 1234,
+            'update_url' => $this->updateUrl(),
         ])->assertOk();
 
         $this->assertDatabaseHas('customers', [
@@ -193,6 +194,7 @@ class WebhooksTest extends FeatureTestCase
             'paddle_status' => Subscription::STATUS_ACTIVE,
             'quantity' => 1,
             'trial_ends_at' => null,
+            'update_url' => $this->updateUrl(),
         ]);
     }
 
@@ -217,6 +219,7 @@ class WebhooksTest extends FeatureTestCase
             'status' => Subscription::STATUS_ACTIVE,
             'subscription_id' => 'bar',
             'subscription_plan_id' => 1234,
+            'update_url' => $this->updateUrl(),
         ])->assertOk();
 
         $this->assertDatabaseHas('customers', [
@@ -233,6 +236,7 @@ class WebhooksTest extends FeatureTestCase
             'paddle_status' => Subscription::STATUS_ACTIVE,
             'quantity' => 1,
             'trial_ends_at' => null,
+            'update_url' => $this->updateUrl(),
         ]);
     }
 
@@ -246,6 +250,7 @@ class WebhooksTest extends FeatureTestCase
             'paddle_plan' => 2323,
             'paddle_status' => Subscription::STATUS_ACTIVE,
             'quantity' => 1,
+            'update_url' => $this->updateUrl($subscriptionId = 1)
         ]);
 
         $this->postJson('paddle/webhook', [
@@ -255,6 +260,7 @@ class WebhooksTest extends FeatureTestCase
             'paused_from' => ($date = now('UTC')->addDays(5))->format('Y-m-d H:i:s'),
             'subscription_id' => 244,
             'subscription_plan_id' => 1234,
+            'update_url' => $this->updateUrl($subscriptionId = 2),
         ])->assertOk();
 
         $this->assertDatabaseHas('subscriptions', [
@@ -267,6 +273,7 @@ class WebhooksTest extends FeatureTestCase
             'paddle_status' => Subscription::STATUS_PAUSED,
             'quantity' => 3,
             'paused_from' => $date,
+            'update_url' => $this->updateUrl($subscriptionId = 2),
         ]);
     }
 
@@ -298,5 +305,10 @@ class WebhooksTest extends FeatureTestCase
             'paddle_status' => Subscription::STATUS_DELETED,
             'ends_at' => $date,
         ]);
+    }
+
+    protected function updateUrl($subscriptionId = 1)
+    {
+        return "https://checkout.paddle.com/subscription/update?user=1&subscription={$subscriptionId}&hash=114493d1810c2dcd45c5cd44d16c3d8484082360";
     }
 }


### PR DESCRIPTION
This PR stores the `update_url` that comes with every `subscription_created` and `subscription_updated` webhook to the database.

This will save an HTTP request to Paddle when you want to show the url.

**Before:** the update_url will be fetched from Paddle every time you visit the page on which this link is stored. 
**After:** the update_url is stored in the database and part of the `Subscription` model.

Because the package is in beta I removed the `updateUrl()` function on `Subscription`. To prevent a breaking change this could be changed to return the `update_url` property from the function instead.

[Paddle documentation](https://developer.paddle.com/guides/how-tos/subscriptions/update-payment-details)
