### PR TITLE
Update webhook events to be more expressive

### DIFF
--- a/src/Events/PaymentSucceeded.php
+++ b/src/Events/PaymentSucceeded.php
@@ -1,0 +1,42 @@
+<?php
+namespace Laravel\Paddle\Events;
+
+use Laravel\Paddle\Receipt;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class PaymentSucceeded
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    /**
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    public $billable;
+
+    /**
+     * @var \Laravel\Paddle\Receipt
+     */
+    public $receipt;
+
+    /**
+     * @var array
+     */
+    public $payload;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $billable
+     * @param  \Laravel\Paddle\Receipt  $receipt
+     * @return void
+     */
+    public function __construct(Model $billable, Receipt $receipt, array $payload)
+    {
+        $this->billable = $billable;
+        $this->receipt = $receipt;
+        $this->payload = $payload;
+    }
+}

--- a/src/Events/SubscriptionCancelled.php
+++ b/src/Events/SubscriptionCancelled.php
@@ -1,0 +1,34 @@
+<?php
+namespace Laravel\Paddle\Events;
+
+use Laravel\Paddle\Subscription;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class SubscriptionCancelled
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    /**
+     * @var \Laravel\Paddle\Subscription
+     */
+    public $subscription;
+
+    /**
+     * @var array
+     */
+    public $payload;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Laravel\Paddle\Subscription  $subscription
+     * @return void
+     */
+    public function __construct(Subscription $subscription, array $payload)
+    {
+        $this->subscription = $subscription;
+        $this->payload = $payload;
+    }
+}

--- a/src/Events/SubscriptionCreated.php
+++ b/src/Events/SubscriptionCreated.php
@@ -1,0 +1,42 @@
+<?php
+namespace Laravel\Paddle\Events;
+
+use Laravel\Paddle\Subscription;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class SubscriptionCreated
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    /**
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    public $billable;
+
+    /**
+     * @var \Laravel\Paddle\Subscription
+     */
+    public $subscription;
+
+    /**
+     * @var array
+     */
+    public $payload;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $billable
+     * @param  \Laravel\Paddle\Subscription  $subscription
+     * @return void
+     */
+    public function __construct(Model $billable, Subscription $subscription, array $payload)
+    {
+        $this->billable = $billable;
+        $this->subscription = $subscription;
+        $this->payload = $payload;
+    }
+}

--- a/src/Events/SubscriptionPaymentSucceeded.php
+++ b/src/Events/SubscriptionPaymentSucceeded.php
@@ -1,0 +1,52 @@
+<?php
+namespace Laravel\Paddle\Events;
+
+use Laravel\Paddle\Receipt;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class SubscriptionPaymentSucceeded
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    /**
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    public $billable;
+
+    /**
+     * @var \Laravel\Paddle\Receipt
+     */
+    public $receipt;
+
+    /**
+     * @var array
+     */
+    public $payload;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $billable
+     * @param  \Laravel\Paddle\Receipt  $receipt
+     * @return void
+     */
+    public function __construct(Model $billable, Receipt $receipt, array $payload)
+    {
+        $this->billable = $billable;
+        $this->receipt = $receipt;
+        $this->payload = $payload;
+    }
+
+    /**
+     * Indicates whether it is the customer’s first payment for this subscription.
+     *
+     * @return bool
+     */
+    public function isInitialPayment()
+    {
+        return $this->payload['initial_payment'] === 1;
+    }
+}

--- a/src/Events/SubscriptionUpdated.php
+++ b/src/Events/SubscriptionUpdated.php
@@ -1,0 +1,34 @@
+<?php
+namespace Laravel\Paddle\Events;
+
+use Laravel\Paddle\Subscription;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class SubscriptionUpdated
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    /**
+     * @var \Laravel\Paddle\Subscription
+     */
+    public $subscription;
+
+    /**
+     * @var array
+     */
+    public $payload;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Laravel\Paddle\Subscription  $subscription
+     * @return void
+     */
+    public function __construct(Subscription $subscription, array $payload)
+    {
+        $this->subscription = $subscription;
+        $this->payload = $payload;
+    }
+}


### PR DESCRIPTION
This PR adds events dedicated to existing webhook methods with the goal of abstracting Paddle also on the webhook layer, and making hooking into Cashier events easier & more expressive.

- Benefit for developers: No need to look into the Paddle documentation when trying to hook into Cashier events, less and more expressive code
- Does not break exiting features because: Existing, "raw" events have not been deleted. Events were added only.
- Tests: extended