### PR TITLE
[1.x] Added function to see when the trial is ending

### DIFF
--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -77,7 +77,7 @@ trait ManagesSubscriptions
     }
 
     /**
-     * Get the date of when the trial ends.
+     * Get the ending date of the trial.
      *
      * @param  string  $name
      * @return Illuminate\Support\Carbon|null

--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -77,6 +77,21 @@ trait ManagesSubscriptions
     }
 
     /**
+     * Get the date of when the trial ends
+     *
+     * @param  string  $name
+     * @return Illuminate\Support\Carbon|null
+     */
+    public function trialEndsAt($name = 'default')
+    {
+        if ($this->onGenericTrial()) {
+            return $this->customer->trial_ends_at;
+        }
+
+        return $this->subscription($name)->trial_ends_at;
+    }
+
+    /**
      * Determine if the Billable model has a given subscription.
      *
      * @param  string  $name

--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -77,7 +77,7 @@ trait ManagesSubscriptions
     }
 
     /**
-     * Get the date of when the trial ends
+     * Get the date of when the trial ends.
      *
      * @param  string  $name
      * @return Illuminate\Support\Carbon|null

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -55,6 +55,7 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($billable->onGenericTrial());
         $this->assertTrue($billable->onTrial());
         $this->assertFalse($billable->onTrial('main'));
+        $this->assertEquals($billable->trialEndsAt(), Carbon::tomorrow());
     }
 
     public function test_customers_can_check_if_their_subscription_is_on_trial()
@@ -80,6 +81,7 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($billable->onTrial('main', 2323));
         $this->assertFalse($billable->onTrial('main', 323));
         $this->assertFalse($billable->onGenericTrial());
+        $this->assertEquals($billable->trialEndsAt('main'), Carbon::tomorrow());
 
         $this->assertTrue($subscription->valid());
         $this->assertTrue($subscription->active());


### PR DESCRIPTION

PR adds a `trialEndsAt` function to the `Billable` trait.

This allows you to write code like this:

```
@if ($user->onTrial())
    Your trial ends at {{ $user->trialEndsAt() }}.
@endif
```

Without this you'd first have to check whether the trial is generic or tied to a subscription.

It also lets you pass in a subscription name as the parameter (`$user->trialEndsAt('main')`).