### PR TITLE
[1.x] Allow payload override

### DIFF
--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -53,9 +53,9 @@ trait PerformsCharges
      */
     protected function generatePayLink(array $payload)
     {
-        $payload['customer_email'] = (string) $this->paddleEmail();
-        $payload['customer_country'] = (string) $this->paddleCountry();
-        $payload['customer_postcode'] = (string) $this->paddlePostcode();
+        $payload['customer_email'] = $payload['customer_email'] ?? (string) $this->paddleEmail();
+        $payload['customer_country'] = $payload['customer_country'] ?? (string) $this->paddleCountry();
+        $payload['customer_postcode'] = $payload['customer_postcode'] ?? (string) $this->paddlePostcode();
 
         // We'll need a way to identify the user in any webhook we're catching so before
         // we make the API request we'll attach the authentication identifier to this


### PR DESCRIPTION
This will allow developers to override some customer settings through the options of various method calls that generate pay links.