### PR TITLE
[1.x] Fix trial ends at

### DIFF
--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -84,7 +84,7 @@ trait ManagesSubscriptions
      */
     public function trialEndsAt($name = 'default')
     {
-        if ($this->onGenericTrial()) {
+        if (is_null($this->subscription($name))) {
             return $this->customer->trial_ends_at;
         }
 

--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -84,11 +84,11 @@ trait ManagesSubscriptions
      */
     public function trialEndsAt($name = 'default')
     {
-        if (is_null($this->subscription($name))) {
-            return $this->customer->trial_ends_at;
+        if ($subscription = $this->subscription($name)) {
+            return $subscription->trial_ends_at;
         }
 
-        return $this->subscription($name)->trial_ends_at;
+        return $this->customer->trial_ends_at;
     }
 
     /**

--- a/tests/Feature/CustomerTest.php
+++ b/tests/Feature/CustomerTest.php
@@ -28,4 +28,12 @@ class CustomerTest extends FeatureTestCase
         $this->assertEmpty($user->receipts);
         $this->assertNull($user->subscription());
     }
+
+    public function test_trial_ends_at_works_if_generic_trial_is_expired()
+    {
+        $user = $this->createUser();
+        $user->createAsCustomer(['trial_ends_at' => $trialEndsAt = now()->subDays(15)]);
+
+        $this->assertSame($trialEndsAt->timestamp, $user->trialEndsAt()->timestamp);
+    }
 }

--- a/tests/Feature/CustomerTest.php
+++ b/tests/Feature/CustomerTest.php
@@ -11,6 +11,7 @@ class CustomerTest extends FeatureTestCase
         $customer = $user->createAsCustomer(['trial_ends_at' => $trialEndsAt = now()->addDays(15)]);
 
         $this->assertSame($trialEndsAt->timestamp, $customer->trial_ends_at->timestamp);
+        $this->assertSame($trialEndsAt->timestamp, $user->trialEndsAt()->timestamp);
         $this->assertTrue($user->onGenericTrial());
     }
 


### PR DESCRIPTION
Fixes #85 

### Problem
Currently the `trialEndsAt` method checks if the user is on a generic trial. If it is then `trial_ends_at` on the User table will be returned. If it's not the trial of a subscription record will be returned.

This means that if a user used to be on a generic trial which is now expired, it will look for a (non-existent) subscription record instead of the `trial_ends_at` field and throw an exception.

### Solution
With this PR `trialEndsAt` will check if there is a subscription. If there is not a subscription it will return the date from the `trial_ends_at` field. If there is a subscription, it will return the subscription.
