### PR TITLE
Adds subscription modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
- # Release Notes
+# Release Notes
 
 ## [Unreleased](https://github.com/laravel/cashier-paddle/compare/v1.2.3...1.x)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release Notes
+ # Release Notes
 
 ## [Unreleased](https://github.com/laravel/cashier-paddle/compare/v1.2.3...1.x)
 

--- a/database/migrations/2020_10_22_000004_create_modifiers_table.php
+++ b/database/migrations/2020_10_22_000004_create_modifiers_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateModifiersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('modifiers', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('subscription_id')->index();
+            $table->integer('paddle_id')->unique();
+            $table->boolean('recurring');
+            $table->string('amount');
+            $table->string('description');
+            $table->timestamp('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('modifiers');
+    }
+}

--- a/database/migrations/2020_10_22_000004_create_modifiers_table.php
+++ b/database/migrations/2020_10_22_000004_create_modifiers_table.php
@@ -17,9 +17,9 @@ class CreateModifiersTable extends Migration
             $table->id();
             $table->unsignedBigInteger('subscription_id')->index();
             $table->integer('paddle_id')->unique();
-            $table->boolean('recurring');
-            $table->string('amount');
             $table->string('description');
+            $table->string('amount');
+            $table->boolean('recurring');
             $table->timestamp('created_at');
         });
     }

--- a/src/Modifier.php
+++ b/src/Modifier.php
@@ -14,4 +14,14 @@ class Modifier extends Model
      * @var array
      */
     protected $guarded = [];
+
+    /**
+     * Get the subscription related to the modifier.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function subscription()
+    {
+        return $this->belongsTo(Subscription::class);
+    }
 }

--- a/src/Modifier.php
+++ b/src/Modifier.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Laravel\Paddle;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Modifier extends Model
+{
+    const UPDATED_AT = null;
+
+    /**
+     * The attributes that are not mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+}

--- a/src/Modifier.php
+++ b/src/Modifier.php
@@ -24,4 +24,20 @@ class Modifier extends Model
     {
         return $this->belongsTo(Subscription::class);
     }
+
+    /**
+     * Deletes itself in the database and on Paddle.
+     *
+     * @return bool|null
+     */
+    public function delete()
+    {
+        $payload = $this->subscription->billable->paddleOptions([
+            'modifier_id' => $this->paddle_id,
+        ]);
+
+        Cashier::post('/subscription/modifiers/delete', $payload);
+
+        return parent::delete();
+    }
 }

--- a/src/ModifierBuilder.php
+++ b/src/ModifierBuilder.php
@@ -93,6 +93,10 @@ class ModifierBuilder
      */
     public function create()
     {
+        if (is_null($this->amount)) {
+            throw new InvalidArgumentException('Amount is a required property.');
+        }
+
         if (strlen($this->description) > 255) {
             throw new InvalidArgumentException('Description has a maximum length of 255 characters.');
         }

--- a/src/ModifierBuilder.php
+++ b/src/ModifierBuilder.php
@@ -3,7 +3,6 @@
 namespace Laravel\Paddle;
 
 use InvalidArgumentException;
-use Laravel\Paddle\Cashier;
 
 class ModifierBuilder
 {
@@ -86,7 +85,7 @@ class ModifierBuilder
     }
 
     /**
-     * Create the modifier
+     * Create the modifier.
      *
      * @return \Laravel\Paddle\Modifier
      *

--- a/src/ModifierBuilder.php
+++ b/src/ModifierBuilder.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Laravel\Paddle;
+
+use InvalidArgumentException;
+use Laravel\Paddle\Cashier;
+
+class ModifierBuilder
+{
+    /**
+     * The Subscription model the modifier belongs to.
+     *
+     * @var \Laravel\Paddle\Subscription
+     */
+    protected $subscription;
+
+    /**
+     * The amount of the modifier.
+     *
+     * @var int
+     */
+    protected $amount;
+
+    /**
+     * The description of the modifier.
+     *
+     * @var string
+     */
+    protected $description = '';
+
+    /**
+     * Indicates whether the modifier should recur.
+     *
+     * @var bool
+     */
+    protected $recurring = true;
+
+    /**
+     * Create a new modifier builder instance.
+     *
+     * @param  \Laravel\Paddle\Subscription  $subscription
+     * @return void
+     */
+    public function __construct($subscription)
+    {
+        $this->subscription = $subscription;
+    }
+
+    /**
+     * Specify the amount of the modifier.
+     *
+     * @param  int  $amount
+     * @return $this
+     */
+    public function amount($amount)
+    {
+        $this->amount = $amount;
+
+        return $this;
+    }
+
+    /**
+     * Specify the description of the modifier.
+     *
+     * @param  string  $description
+     * @return $this
+     */
+    public function description($description)
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    /**
+     * Specify whether the modifier should recur.
+     *
+     * @param  bool  $amount
+     * @return $this
+     */
+    public function recurring($recurring)
+    {
+        $this->recurring = $recurring;
+
+        return $this;
+    }
+
+    /**
+     * Create the modifier
+     *
+     * @return \Laravel\Paddle\Modifier
+     *
+     * @throws \Exception
+     */
+    public function create()
+    {
+        if (strlen($this->description) > 255) {
+            throw new InvalidArgumentException('Description has a maximum length of 255 characters.');
+        }
+
+        $response = Cashier::post('/subscription/modifiers/create', $this->buildPayload())['response'];
+
+        return $this->subscription->modifiers()->create([
+            'paddle_id' => $response['modifier_id'],
+            'amount' => $this->amount,
+            'description' => $this->description,
+            'recurring' => $this->recurring,
+        ]);
+    }
+
+    /**
+     * Build the payload for modifier creation.
+     *
+     * @return array
+     */
+    protected function buildPayload()
+    {
+        return $this->subscription->billable->paddleOptions([
+            'subscription_id' => $this->subscription->paddle_id,
+            'modifier_amount' => $this->amount,
+            'modifier_description' => $this->description,
+            'modifier_recurring' => $this->recurring,
+        ]);
+    }
+}

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -2,11 +2,13 @@
 
 namespace Laravel\Paddle;
 
-use Carbon\Carbon;
 use Exception;
-use Illuminate\Database\Eloquent\Model;
-use Laravel\Paddle\Concerns\Prorates;
+use Carbon\Carbon;
 use LogicException;
+use Laravel\Paddle\Modifier;
+use Laravel\Paddle\ModifierBuilder;
+use Laravel\Paddle\Concerns\Prorates;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * @property \Laravel\Paddle\Billable $billable
@@ -641,6 +643,26 @@ class Subscription extends Model
         $payment = $this->paddleInfo()['next_payment'];
 
         return new Payment($payment['amount'], $payment['currency'], $payment['date']);
+    }
+
+    /**
+     * Begin creating a new modifier.
+     *
+     * @return \Laravel\Paddle\ModifierBuilder
+     */
+    public function newModifier()
+    {
+        return new ModifierBuilder($this);
+    }
+
+    /**
+     * Get all of the modifiers for this subscription.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function modifiers()
+    {
+        return $this->hasMany(Modifier::class);
     }
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -664,6 +664,17 @@ class Subscription extends Model
     }
 
     /**
+     * Get a modifier instance by name.
+     *
+     * @param  int  $id
+     * @return \Laravel\Paddle\Modifier|null
+     */
+    public function modifier($id)
+    {
+        return $this->modifiers->find($id);
+    }
+
+    /**
      * Get the email address of the customer associated to this subscription.
      *
      * @return string

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -2,13 +2,11 @@
 
 namespace Laravel\Paddle;
 
-use Exception;
 use Carbon\Carbon;
-use LogicException;
-use Laravel\Paddle\Modifier;
-use Laravel\Paddle\ModifierBuilder;
-use Laravel\Paddle\Concerns\Prorates;
+use Exception;
 use Illuminate\Database\Eloquent\Model;
+use LogicException;
+use Laravel\Paddle\Concerns\Prorates;
 
 /**
  * @property \Laravel\Paddle\Billable $billable

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -5,8 +5,8 @@ namespace Laravel\Paddle;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Database\Eloquent\Model;
-use LogicException;
 use Laravel\Paddle\Concerns\Prorates;
+use LogicException;
 
 /**
  * @property \Laravel\Paddle\Billable $billable

--- a/tests/Feature/ModifiersTest.php
+++ b/tests/Feature/ModifiersTest.php
@@ -15,8 +15,8 @@ class ModifiersTest extends FeatureTestCase
                 'response' => [
                     'subscription_id' => $_SERVER['PADDLE_TEST_SUBSCRIPTION'],
                     'modifier_id' => 6789,
-                ]
-            ])
+                ],
+            ]),
         ]);
 
         $billable = $this->createBillable('taylor');
@@ -56,8 +56,8 @@ class ModifiersTest extends FeatureTestCase
     {
         Http::fake([
             'https://vendors.paddle.com/api/2.0/subscription/modifiers/delete' => Http::response([
-                'success' => true
-            ])
+                'success' => true,
+            ]),
         ]);
 
         $billable = $this->createBillable('taylor');

--- a/tests/Feature/ModifiersTest.php
+++ b/tests/Feature/ModifiersTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Paddle\Subscription;
+
+class ModifiersTest extends FeatureTestCase
+{
+    public function test_subscriptions_can_create_modifiers()
+    {
+        Http::fake([
+            'https://vendors.paddle.com/api/2.0/subscription/modifiers/create' => Http::response([
+                'success' => true,
+                'response' => [
+                    'subscription_id' => $_SERVER['PADDLE_TEST_SUBSCRIPTION'],
+                    'modifier_id' => 6789,
+                ]
+            ])
+        ]);
+
+        $billable = $this->createBillable('taylor');
+
+        $subscription = $billable->subscriptions()->create([
+            'name' => 'main',
+            'paddle_id' => $_SERVER['PADDLE_TEST_SUBSCRIPTION'],
+            'paddle_plan' => 12345,
+            'paddle_status' => Subscription::STATUS_ACTIVE,
+            'quantity' => 1,
+        ]);
+
+        $modifier = $subscription->newModifier()
+            ->amount(15.00)
+            ->description('Our test description')
+            ->recurring(false)
+            ->create();
+
+        Http::assertSent(function ($request) {
+            return $request['subscription_id'] == $_SERVER['PADDLE_TEST_SUBSCRIPTION'] &&
+                   $request['modifier_amount'] == 15.00 &&
+                   $request['modifier_description'] == 'Our test description' &&
+                   $request['modifier_recurring'] == false;
+        });
+
+        $this->assertEquals($modifier->id, $subscription->modifier($modifier->id)->id);
+        $this->assertDatabaseHas('modifiers', [
+            'subscription_id' => $subscription->id,
+            'paddle_id' => 6789,
+            'amount' => 15.00,
+            'description' => 'Our test description',
+            'recurring' => false,
+        ]);
+    }
+}


### PR DESCRIPTION
**This PR is a draft until there's consensus on what it should look like.**

Implements #71 

Paddle subscription prices are fixed and require a modifier to change. Modifiers allow you to implement metered billing or add-on subscriptions.

### Examples
**Subscription add-ons**
User is subscribed to a webshop builder for $100/month. The shipping plugin costs $20/month.
Total cost is $120/month.

**Metered billing with base plan**
User is subscribed to a plan which allows for 100.000 API calls for $100/month and subsequent calls are $2 / 1000 calls.
When a user uses 120.000 API calls the total cost is $100 + (20.000/1.000) * $2 = $140.

**Metered billing without a base plan**
~~Contacted Paddle how to approach this. Will update later.~~
Paddle says it's not possible to do this without a base plan. They suggest a $0 subscription and using quantity to set the right amount. This doesn't involve modifiers / this PR.

### Implementation
`Subscription` would have a `hasMany()` relationship to modifiers so a new database table would be created.

**Create a modifier and attach to a subscription**
```php
$user->subscription()->newModifier()
    ->amount(15.00)
    ->description('Webshop add-on')
    ->recurring(true)
    ->create();
```

**Get all modifiers**
```php
$user->subscription()->modifiers;
```

**Get specific modifier**
```php
$user->subscription()->modifier('modifier_id');
```

**Remove modifier**
```php
$user->subscription()->modifier('modifier_id')->delete();
```

### To-do

- [x] Modifiers can be created
- [x] Modifiers can be accessed
- [x] Modifiers can be deleted
- [ ] Modifiers can be synced from Paddle with a command.