### PR TITLE
[1.x] Fix bug with cancelNow

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -228,9 +228,11 @@ class WebhookController extends Controller
         }
 
         // Cancellation date...
-        $subscription->ends_at = $subscription->onTrial()
-            ? $subscription->trial_ends_at
-            : Carbon::createFromFormat('Y-m-d', $payload['cancellation_effective_date'], 'UTC')->startOfDay();
+        if (is_null($subscription->ends_at)) {
+            $subscription->ends_at = $subscription->onTrial()
+                ? $subscription->trial_ends_at
+                : Carbon::createFromFormat('Y-m-d', $payload['cancellation_effective_date'], 'UTC')->startOfDay();
+        }
 
         // Status...
         if (isset($payload['status'])) {


### PR DESCRIPTION
This fixes a bug with `cancelNow` where the incoming webhook from Paddle would sometimes overwrite the `Carbon::now()` timestamp from the `cancelNow` method. We're checking if the `ends_at` attribute hasn't been filled out yet before proceeding. Since it's impossible to restart cancelled subscriptions in Paddle we should be good with just this change.

Fixes https://github.com/laravel/cashier-paddle/issues/92