### PR TITLE
[1.x] Fix cancel subscription

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -602,11 +602,13 @@ class Subscription extends Model
             return $this;
         }
 
-        $nextPayment = $this->nextPayment();
-
-        $endsAt = $this->onTrial()
-                    ? $this->trial_ends_at
-                    : $nextPayment->date();
+        if ($this->onPausedGracePeriod() || $this->paused()) {
+            $endsAt = $this->paused_from;
+        } else {
+            $endsAt = $this->onTrial()
+                ? $this->trial_ends_at
+                : $this->nextPayment()->date();
+        }
 
         return $this->cancelAt($endsAt);
     }


### PR DESCRIPTION
This fixes a bug where cancelling paused subscriptions was still trying to retrieve the next payment date as an end date. Because there's no next payment date for paused subscriptions this was failing. The fix now uses the start of the pause date as the new end date.

Also contains a small refactor to simplify the logic of cancelling subscriptions and prevent code duplication.

Fixes https://github.com/laravel/cashier-paddle/issues/100