### PR TITLE
[1.x] Use cancel now when cancelling paused subscriptions

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -603,7 +603,9 @@ class Subscription extends Model
         }
 
         if ($this->onPausedGracePeriod() || $this->paused()) {
-            $endsAt = $this->paused_from;
+            $endsAt = $this->paused_from->isFuture()
+                ? $this->paused_from
+                : Carbon::now();
         } else {
             $endsAt = $this->onTrial()
                 ? $this->trial_ends_at


### PR DESCRIPTION
This is a follow up for https://github.com/laravel/cashier-paddle/pull/101. ~I realised it actually makes more sense to cancel the subscription immediately when a customer explicitly cancels a paused subscription.~

Now sets the ends_at timestamp correctly when the subscription was paused in the past.