### PR TITLE
[1.x] Fix too strict code on API call

### DIFF
--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -20,7 +20,7 @@ trait PerformsCharges
      */
     public function charge($amount, $title, array $options = [])
     {
-        if (strlen($title) > 100) {
+        if (strlen($title) > 200) {
             throw new InvalidArgumentException('Charge title has a maximum length of 100 characters.');
         }
 

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -21,7 +21,7 @@ trait PerformsCharges
     public function charge($amount, $title, array $options = [])
     {
         if (strlen($title) > 200) {
-            throw new InvalidArgumentException('Charge title has a maximum length of 100 characters.');
+            throw new InvalidArgumentException('Charge title has a maximum length of 200 characters.');
         }
 
         return $this->generatePayLink(array_merge([


### PR DESCRIPTION
Code checks for a maximum length of 100 on the `title` attribute while according to [the docs](https://developer.paddle.com/api-reference/product-api/pay-links/createpaylink) 200 characters are allowed.