### PR TITLE
[1.x] Avoid errors for PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "illuminate/view": "^7.9|^8.0",
         "moneyphp/money": "^3.2",
         "nesbot/carbon": "^2.0",
-        "spatie/url": "^1.3.5",
+        "spatie/url": "^1.3.5|^2.0",
         "symfony/http-kernel": "^5.0",
         "symfony/intl": "^5.0"
     },


### PR DESCRIPTION
Consider the following failure: https://github.com/renoki-co/cashier-register/pull/27/checks?check_run_id=2547701014

```
Problem 1
    - laravel/cashier-paddle[v1.4.0, ..., 1.x-dev] require spatie/url ^1.3.5 -> satisfiable by spatie/url[1.3.5].
    - spatie/url 1.3.5 requires spatie/macroable ^1.0.1 -> found spatie/macroable[1.0.1] but the package is fixed to 2.0.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
    - Root composer.json requires laravel/cashier-paddle ^1.4 -> satisfiable by laravel/cashier-paddle[v1.4.0, ..., 1.x-dev].

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
Error: Your requirements could not be resolved to an installable set of packages.
```