### PR TITLE
[1.x] Trim whitespace for pay link values

### DIFF
--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -73,6 +73,10 @@ trait PerformsCharges
 
         $payload['passthrough'] = json_encode($payload['passthrough']);
 
+        $payload = array_map(function ($value) {
+            return is_string($value) ? trim($value) : $value;
+        }, $payload);
+
         return Cashier::post('/product/generate_pay_link', $payload)['response']['url'];
     }
 


### PR DESCRIPTION
When trailing white spaces occurs on values for the pay link's payload, Laravel will strip these with the `TrimStrings` middleware and thus the signature verification from Paddle will fail. It's best that we trim all strings before generating the pay link. 

Fixes https://github.com/laravel/cashier-paddle/issues/120