### PR TITLE
[2.x] Fixed trial ends at

### DIFF
--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -85,6 +85,10 @@ trait ManagesSubscriptions
      */
     public function trialEndsAt($name = 'default')
     {
+        if (func_num_args() === 0 && $this->onGenericTrial()) {
+            return $this->customer->trial_ends_at;
+        }
+
         if ($subscription = $this->subscription($name)) {
             return $subscription->trial_ends_at;
         }

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -94,6 +94,24 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertFalse($subscription->ended());
     }
 
+    public function test_user_with_subscription_can_return_generic_trial_end_date()
+    {
+        $billable = $this->createBillable('taylor', ['trial_ends_at' => $tomorrow = Carbon::tomorrow()]);
+
+        $subscription = $billable->subscriptions()->create([
+            'name' => 'default',
+            'paddle_id' => 244,
+            'paddle_plan' => 2323,
+            'paddle_status' => Subscription::STATUS_ACTIVE,
+            'quantity' => 1,
+        ]);
+
+        $this->assertTrue($billable->onGenericTrial());
+        $this->assertTrue($billable->onTrial());
+        $this->assertFalse($subscription->onTrial());
+        $this->assertEquals($tomorrow, $billable->trialEndsAt());
+    }
+
     public function test_customers_can_check_if_their_subscription_is_cancelled()
     {
         $billable = $this->createBillable('taylor');


### PR DESCRIPTION
Closes #122 and is a replica of laravel/cashier-stripe#1129.

When on a generic trial but also having an active subscription, it will now return the ending date of the generic trial instead of the subscription.