### PR TITLE
[1.x] Fix refunds

### DIFF
--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -3,7 +3,6 @@
 namespace Laravel\Paddle\Concerns;
 
 use Laravel\Paddle\Cashier;
-use Laravel\Paddle\Customer;
 
 trait ManagesCustomer
 {

--- a/src/Concerns/PerformsCharges.php
+++ b/src/Concerns/PerformsCharges.php
@@ -99,6 +99,6 @@ trait PerformsCharges
             $payload['amount'] = $amount;
         }
 
-        return Cashier::post('/payment/refund', $payload)['refund_request_id'];
+        return Cashier::post('/payment/refund', $payload)['response']['refund_request_id'];
     }
 }

--- a/tests/Feature/ChargesTest.php
+++ b/tests/Feature/ChargesTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Support\Facades\Http;
 use Laravel\Paddle\Cashier;
 
 class ChargesTest extends FeatureTestCase
@@ -30,5 +31,23 @@ class ChargesTest extends FeatureTestCase
         $url = $billable->chargeProduct($_SERVER['PADDLE_TEST_PRODUCT']);
 
         $this->assertStringContainsString(Cashier::checkoutUrl().'/checkout/custom/', $url);
+    }
+
+    public function test_payments_can_be_refunded()
+    {
+        $billable = $this->createBillable();
+
+        Http::fake([
+            'vendors.paddle.com/api/2.0/payment/refund' => Http::response([
+                'success' => true,
+                'response' => [
+                    'refund_request_id' => 12345,
+                ],
+            ]),
+        ]);
+
+        $response = $billable->refund(4321, 12.50, 'Incorrect order');
+
+        $this->assertSame(12345, $response);
     }
 }


### PR DESCRIPTION
This fixes an issue with refunds where the response identifier wasn't properly located in the JSON response.

Fixes https://github.com/laravel/cashier-paddle/issues/130
