### PR TITLE
[1.x] Allow moneyphp version 4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip
+          extensions: dom, curl, libxml, mbstring, zip, bcmath
           tools: composer:v2
           coverage: none
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "ext-bcmath": "*",
         "ext-json": "*",
         "ext-openssl": "*",
         "guzzlehttp/guzzle": "^6.5|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
+        "ext-bcmath": "*",
         "ext-json": "*",
         "ext-openssl": "*",
         "guzzlehttp/guzzle": "^6.5|^7.0",
@@ -28,7 +29,7 @@
         "illuminate/routing": "^7.9|^8.0",
         "illuminate/support": "^7.9|^8.0",
         "illuminate/view": "^7.9|^8.0",
-        "moneyphp/money": "^3.2",
+        "moneyphp/money": "^3.2|^4.0",
         "nesbot/carbon": "^2.0",
         "spatie/url": "^1.3.5",
         "symfony/http-kernel": "^5.0",


### PR DESCRIPTION
This adds the same changes like https://github.com/laravel/cashier-stripe/pull/1280
