### PR TITLE
Update Subscription.php

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -704,7 +704,7 @@ class Subscription extends Model
      */
     public function paymentMethod()
     {
-        return (string) $this->paddleInfo()['payment_information']['payment_method'];
+        return (string) ($this->paddleInfo()['payment_information']['payment_method'] ?? '');
     }
 
     /**


### PR DESCRIPTION
Allow paymentMethod() to be empty string. Subscriptions with "state": "deleted" don't have ```payment_information``` and ```payment_method``` respectively.

Solves https://github.com/laravel/cashier-paddle/issues/147
