### PR TITLE
Allow spatie/url 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "illuminate/view": "^7.9|^8.0|^9.0",
         "moneyphp/money": "^3.2|^4.0",
         "nesbot/carbon": "^2.0",
-        "spatie/url": "^1.3.5",
+        "spatie/url": "^1.3.5|^2.0",
         "symfony/http-kernel": "^5.0|^6.0",
         "symfony/intl": "^5.0|^6.0"
     },

--- a/tests/Feature/ChargesTest.php
+++ b/tests/Feature/ChargesTest.php
@@ -8,7 +8,7 @@ class ChargesTest extends FeatureTestCase
 {
     public function test_customers_can_retrieve_a_single_charge_link()
     {
-        if (! isset($_SERVER['PADDLE_VENDOR_ID'], $_SERVER['PADDLE_VENDOR_AUTH_CODE'])) {
+        if (! getenv('PADDLE_VENDOR_ID') || ! getenv('PADDLE_VENDOR_AUTH_CODE')) {
             $this->markTestSkipped('Paddle vendor ID and auth code not configured.');
         }
 
@@ -21,13 +21,13 @@ class ChargesTest extends FeatureTestCase
 
     public function test_customers_can_retrieve_a_product_charge_link()
     {
-        if (! isset($_SERVER['PADDLE_TEST_PRODUCT'])) {
+        if (! getenv('PADDLE_TEST_PRODUCT')) {
             $this->markTestSkipped('Test product not configured.');
         }
 
         $billable = $this->createBillable();
 
-        $url = $billable->chargeProduct($_SERVER['PADDLE_TEST_PRODUCT']);
+        $url = $billable->chargeProduct(getenv('PADDLE_TEST_PRODUCT'));
 
         $this->assertStringContainsString('/checkout/custom/', $url);
     }

--- a/tests/Feature/PricesTest.php
+++ b/tests/Feature/PricesTest.php
@@ -9,11 +9,11 @@ class PricesTest extends FeatureTestCase
 {
     public function test_it_can_fetch_the_prices_of_products()
     {
-        if (! isset($_SERVER['PADDLE_TEST_PRODUCT'])) {
+        if (! getenv('PADDLE_TEST_PRODUCT')) {
             $this->markTestSkipped('Test product not configured.');
         }
 
-        $prices = Cashier::productPrices([$_SERVER['PADDLE_TEST_PRODUCT']]);
+        $prices = Cashier::productPrices([getenv('PADDLE_TEST_PRODUCT')]);
 
         $this->assertNotEmpty($prices);
         $this->assertContainsOnlyInstancesOf(ProductPrice::class, $prices->all());


### PR DESCRIPTION
Simple change to also allow `spatie/url` in version 2.0, which raises the minimum to PHP 8.0 (and proper PHP 8.1 support respectively), but does not have any breaking changes, just feature updates.

People on PHP <8.0 can still use the 1.0 version.