### PR TITLE
Filter query by active, on trial, or within its grace period. (Filter query by valid)

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -93,7 +93,7 @@ class Subscription extends Model
 
     /**
      * Filter query by active, on trial, or within its grace period.
-     * 
+     *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return void
      */

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -92,6 +92,29 @@ class Subscription extends Model
     }
 
     /**
+     * Filter query by active, on trial, or within its grace period.
+     * 
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return void
+     */
+    public function scopeValid($query)
+    {
+        $query->active()
+            ->orWhere(function ($query) {
+                $query->active();
+            })
+            ->orWhere(function ($query) {
+                $query->onTrial();
+            })
+            ->orWhere(function ($query) {
+                $query->onPausedGracePeriod();
+            })
+            ->orWhere(function ($query) {
+                $query->onGracePeriod();
+            });
+    }
+
+    /**
      * Determine if the subscription is active.
      *
      * @return bool


### PR DESCRIPTION
If I need to get all Subscription Valid : 
```php
Subscription::active()
        ->orWhere(function (Builder $query) {
            $query->active();
        })
        ->orWhere(function (Builder $query) {
            $query->onTrial();
        })
        ->orWhere(function (Builder $query) {
            $query->onPausedGracePeriod();
        })
        ->orWhere(function (Builder $query) {
            $query->onGracePeriod();
        })->get();
```
Now : 
```php
Subscription::valid()->get();
```