### PR TITLE
[1.x] Pass locale to custom format amount

### DIFF
--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -196,7 +196,7 @@ class Cashier
     public static function formatAmount($amount, $currency = null, $locale = null)
     {
         if (static::$formatCurrencyUsing) {
-            return call_user_func(static::$formatCurrencyUsing, $amount, $currency);
+            return call_user_func(static::$formatCurrencyUsing, $amount, $currency, $locale);
         }
 
         $money = new Money($amount, new Currency(strtoupper($currency ?? config('cashier.currency'))));


### PR DESCRIPTION
This will allow an underlying library to use the given locale in a custom formatter.
