### PR TITLE
Add a `fake` method to Cashier

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,8 +8,9 @@ You will need to set some environment variables in a custom `phpunit.xml` file i
 
 Copy the default file using `cp phpunit.xml.dist phpunit.xml` and add the following lines below the `DB_CONNECTION` environment variable in your new `phpunit.xml` file:
 
-    <server name="PADDLE_VENDOR_ID" value="Your Paddle vendor ID"/>
-    <server name="PADDLE_VENDOR_AUTH_CODE" value="Your Paddle auth code"/>
-    <server name="PADDLE_TEST_PRODUCT" value="Identifier for a random one off product"/>
+    <env name="PADDLE_SANDBOX" value="true"/>
+    <env name="PADDLE_VENDOR_ID" value="Your Paddle vendor ID"/>
+    <env name="PADDLE_VENDOR_AUTH_CODE" value="Your Paddle auth code"/>
+    <env name="PADDLE_TEST_PRODUCT" value="Identifier for a random one off product"/>
 
 After setting these variables, you can run your tests by executing the `vendor/bin/phpunit` command.

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -62,7 +62,7 @@ class Cashier
     public static $receiptModel = Receipt::class;
 
     /**
-     * Set up faker instance for Cashier-provided API calls and events
+     * Set up faker instance for Cashier-provided API calls and events.
      *
      * @return \Laravel\Paddle\CashierFake
      */
@@ -295,7 +295,7 @@ class Cashier
     }
 
     /**
-     * Pass-thru to the CashierFake method of the same name
+     * Pass-thru to the CashierFake method of the same name.
      *
      * @param  callable|int|null  $callback
      * @return void
@@ -306,7 +306,7 @@ class Cashier
     }
 
     /**
-     * Pass-thru to the CashierFake method of the same name
+     * Pass-thru to the CashierFake method of the same name.
      *
      * @param  callable|int|null  $callback
      * @return void
@@ -317,7 +317,7 @@ class Cashier
     }
 
     /**
-     * Pass-thru to the CashierFake method of the same name
+     * Pass-thru to the CashierFake method of the same name.
      *
      * @param  callable|int|null  $callback
      * @return void
@@ -328,7 +328,7 @@ class Cashier
     }
 
     /**
-     * Pass-thru to the CashierFake method of the same name
+     * Pass-thru to the CashierFake method of the same name.
      *
      * @param  callable|int|null  $callback
      * @return void
@@ -339,7 +339,7 @@ class Cashier
     }
 
     /**
-     * Pass-thru to the CashierFake method of the same name
+     * Pass-thru to the CashierFake method of the same name.
      *
      * @param  callable|int|null  $callback
      * @return void
@@ -350,7 +350,7 @@ class Cashier
     }
 
     /**
-     * Pass-thru to the CashierFake method of the same name
+     * Pass-thru to the CashierFake method of the same name.
      *
      * @param  callable|int|null  $callback
      * @return void
@@ -361,7 +361,7 @@ class Cashier
     }
 
     /**
-     * Pass-thru to the CashierFake method of the same name
+     * Pass-thru to the CashierFake method of the same name.
      *
      * @param  callable|int|null  $callback
      * @return void

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Paddle;
 
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Laravel\Paddle\Exceptions\PaddleException;
 use Money\Currencies\ISOCurrencies;

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -62,14 +62,13 @@ class Cashier
     public static $receiptModel = Receipt::class;
 
     /**
-     * Fakes the Http responses from the API's endpoints.
+     * Set up faker instance for Cashier-provided API calls and events
      *
-     * @param array $endpoints
      * @return \Laravel\Paddle\CashierFake
      */
-    public static function fake(array $endpoints = [])
+    public static function fake(...$arguments)
     {
-        return CashierFake::fake($endpoints);
+        return CashierFake::fake(...$arguments);
     }
 
     /**

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -2,13 +2,14 @@
 
 namespace Laravel\Paddle;
 
-use Illuminate\Support\Facades\Http;
-use Laravel\Paddle\Exceptions\PaddleException;
-use Money\Currencies\ISOCurrencies;
-use Money\Currency;
-use Money\Formatter\IntlMoneyFormatter;
 use Money\Money;
+use Money\Currency;
 use NumberFormatter;
+use Money\Currencies\ISOCurrencies;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Event;
+use Money\Formatter\IntlMoneyFormatter;
+use Laravel\Paddle\Exceptions\PaddleException;
 
 class Cashier
 {
@@ -60,6 +61,17 @@ class Cashier
      * @var string
      */
     public static $receiptModel = Receipt::class;
+
+    /**
+     * Fakes the Http responses from the API's endpoints.
+     *
+     * @param array $endpoints
+     * @return \Laravel\Paddle\CashierFake
+     */
+    public static function fake(array $endpoints = [])
+    {
+        return CashierFake::fake($endpoints);
+    }
 
     /**
      * Get prices for a set of product ids.
@@ -282,5 +294,82 @@ class Cashier
     public static function useReceiptModel($receiptModel)
     {
         static::$receiptModel = $receiptModel;
+    }
+
+    /**
+     * Pass-thru to the CashierFake method of the same name
+     *
+     * @param  callable|int|null  $callback
+     * @return void
+     */
+    public static function assertPaymentSucceeded($callback = null)
+    {
+        CashierFake::assertPaymentSucceeded($callback);
+    }
+
+    /**
+     * Pass-thru to the CashierFake method of the same name
+     *
+     * @param  callable|int|null  $callback
+     * @return void
+     */
+    public static function assertSubscriptionPaymentSucceeded($callback = null)
+    {
+        CashierFake::assertSubscriptionPaymentSucceeded($callback);
+    }
+
+    /**
+     * Pass-thru to the CashierFake method of the same name
+     *
+     * @param  callable|int|null  $callback
+     * @return void
+     */
+    public static function assertSubscriptionPaymentFailed($callback = null)
+    {
+        CashierFake::assertSubscriptionPaymentFailed($callback);
+    }
+
+    /**
+     * Pass-thru to the CashierFake method of the same name
+     *
+     * @param  callable|int|null  $callback
+     * @return void
+     */
+    public static function assertSubscriptionCreated($callback = null)
+    {
+        CashierFake::assertSubscriptionCreated($callback);
+    }
+
+    /**
+     * Pass-thru to the CashierFake method of the same name
+     *
+     * @param  callable|int|null  $callback
+     * @return void
+     */
+    public static function assertSubscriptionNotCreated($callback = null)
+    {
+        CashierFake::assertSubscriptionNotCreated($callback);
+    }
+
+    /**
+     * Pass-thru to the CashierFake method of the same name
+     *
+     * @param  callable|int|null  $callback
+     * @return void
+     */
+    public static function assertSubscriptionUpdated($callback = null)
+    {
+        CashierFake::assertSubscriptionUpdated($callback);
+    }
+
+    /**
+     * Pass-thru to the CashierFake method of the same name
+     *
+     * @param  callable|int|null  $callback
+     * @return void
+     */
+    public static function assertSubscriptionCancelled($callback = null)
+    {
+        CashierFake::assertSubscriptionCancelled($callback);
     }
 }

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -62,7 +62,7 @@ class Cashier
     public static $receiptModel = Receipt::class;
 
     /**
-     * Set up faker instance for Cashier-provided API calls and events.
+     * Set up CashierFake instance.
      *
      * @return \Laravel\Paddle\CashierFake
      */

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -2,14 +2,14 @@
 
 namespace Laravel\Paddle;
 
-use Money\Money;
-use Money\Currency;
-use NumberFormatter;
-use Money\Currencies\ISOCurrencies;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Event;
-use Money\Formatter\IntlMoneyFormatter;
+use Illuminate\Support\Facades\Http;
 use Laravel\Paddle\Exceptions\PaddleException;
+use Money\Currencies\ISOCurrencies;
+use Money\Currency;
+use Money\Formatter\IntlMoneyFormatter;
+use Money\Money;
+use NumberFormatter;
 
 class Cashier
 {

--- a/src/CashierFake.php
+++ b/src/CashierFake.php
@@ -70,7 +70,7 @@ class CashierFake
     public function paypal(array $paymentInformation = [])
     {
         static::$paymentInformation = array_merge([
-            'payment_method' => 'paypal'
+            'payment_method' => 'paypal',
         ], $paymentInformation);
 
         return $this;

--- a/src/CashierFake.php
+++ b/src/CashierFake.php
@@ -22,6 +22,12 @@ class CashierFake
      */
     protected static $paymentProvider = 'card';
 
+    protected static $cardData = [
+        'card_type' => 'visa',
+        'last_four_digits' => '1234',
+        'expiry_date' => '04/2022',
+    ];
+
     /**
      * Initialize the fake instance
      *
@@ -74,9 +80,10 @@ class CashierFake
      *
      * @return self
      */
-    public function card()
+    public function card($data = [])
     {
         static::$paymentProvider = 'card';
+        static::$cardData = array_merge(static::$cardData, $data);
 
         return $this;
     }
@@ -211,12 +218,7 @@ class CashierFake
                             'user_email' => 'john@example.com',
                             'payment_information' => static::$paymentProvider === 'paypal'
                                 ? ['payment_method' => 'paypal']
-                                : [
-                                    'payment_method' => 'card',
-                                    'card_type' => 'visa',
-                                    'last_four_digits' => '1234',
-                                    'expiry_date' => '04/2022',
-                                ],
+                                : array_merge(['payment_method' => 'card'], static::$cardData),
                             'last_payment' => [
                                 'amount' => 0.00,
                                 'currency' => 'EUR',

--- a/src/CashierFake.php
+++ b/src/CashierFake.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace Laravel\Paddle;
+
+use Illuminate\Support\Str;
+use Mockery\Generator\Method;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Event;
+use Laravel\Paddle\Events\WebhookHandled;
+use Laravel\Paddle\Events\WebhookReceived;
+use Laravel\Paddle\Events\PaymentSucceeded;
+use Laravel\Paddle\Events\SubscriptionCreated;
+use Laravel\Paddle\Events\SubscriptionUpdated;
+use Laravel\Paddle\Events\SubscriptionCancelled;
+use Laravel\Paddle\Events\SubscriptionPaymentFailed;
+use Laravel\Paddle\Events\SubscriptionPaymentSucceeded;
+
+class CashierFake
+{
+    /**
+     * The endpoints that need to be faked
+     *
+     * @var array
+     */
+    protected $endpoints;
+
+    /**
+     * The events that need to be faked
+     *
+     * @var array
+     */
+    protected $events = [
+        PaymentSucceeded::class,
+        SubscriptionCreated::class,
+        SubscriptionCancelled::class,
+        SubscriptionPaymentFailed::class,
+        SubscriptionPaymentSucceeded::class,
+        SubscriptionUpdated::class,
+    ];
+
+    /**
+     * The payment provider to mock the user as (either "paypal" or "card")
+     *
+     * @var string
+     */
+    public static $paymentProvider = 'card';
+
+    /**
+     * Merge the provided endpoints into the default ones for mocking
+     *
+     * @param array $endpoints
+     * @return void
+     */
+    public function __construct(array $endpoints = [])
+    {
+        foreach (array_merge(static::initialEndpoints(), $endpoints) as $endpoint => $data) {
+            $this->mockEndpoint($endpoint, $data);
+        }
+
+        Event::fake($this->events);
+    }
+
+    /**
+     * Syntactic sugar for the constructor
+     *
+     * @return static
+     */
+    public static function fake(array $endpoints = [])
+    {
+        return new static($endpoints);
+    }
+
+    /**
+     * Mock a given endpoint with the provided response data
+     *
+     * @param string $endpoint
+     * @param mixed  $data
+     * @return void
+     */
+    public function mockEndpoint(string $endpoint, $data = [])
+    {
+        $response = ! is_callable($data) ? Http::response($data) : $data;
+
+        Http::fake([
+            $this->formatEndpoint($endpoint) => $data
+        ]);
+    }
+
+    /**
+     * Mock the user as if they used PayPal as a payment provider
+     *
+     * @return self
+     */
+    public function paypal()
+    {
+        static::$paymentProvider = 'paypal';
+
+        return $this;
+    }
+
+    /**
+     * Mock the user as if they used a credit card as a payment provider
+     *
+     * @return self
+     */
+    public function card()
+    {
+        static::$paymentProvider = 'card';
+
+        return $this;
+    }
+
+    /**
+     * Format the given path into a full url
+     *
+     * @param string $path
+     * @return string
+     */
+    protected function formatEndpoint(string $path): string
+    {
+        return Cashier::vendorsUrl()
+               .'/api/'.static::API_VERSION
+               .Str::start($path, '/');
+    }
+
+    /**
+     * Assert if the PaymentSucceeded event was dispatched based on a truth-test callback.
+     *
+     * @param  callable|int|null  $callback
+     * @return void
+     */
+    public static function assertPaymentSucceeded($callback = null)
+    {
+        Event::assertDispatched(PaymentSucceeded::class, $callback);
+    }
+
+    /**
+     * Assert if the SubscriptionPaymentSucceeded event was dispatched based on a truth-test callback.
+     *
+     * @param  callable|int|null  $callback
+     * @return void
+     */
+    public static function assertSubscriptionPaymentSucceeded($callback = null)
+    {
+        Event::assertDispatched(SubscriptionPaymentSucceeded::class, $callback);
+    }
+
+    /**
+     * Assert if the SubscriptionPaymentFailed event was dispatched based on a truth-test callback.
+     *
+     * @param  callable|int|null  $callback
+     * @return void
+     */
+    public static function assertSubscriptionPaymentFailed($callback = null)
+    {
+        Event::assertDispatched(SubscriptionPaymentFailed::class, $callback);
+    }
+
+    /**
+     * Assert if the SubscriptionCreated event was dispatched based on a truth-test callback.
+     *
+     * @param  callable|int|null  $callback
+     * @return void
+     */
+    public static function assertSubscriptionCreated($callback = null)
+    {
+        Event::assertDispatched(SubscriptionCreated::class, $callback);
+    }
+
+    /**
+     * Assert if the SubscriptionCreated event was not dispatched based on a truth-test callback.
+     *
+     * @param  callable|int|null  $callback
+     * @return void
+     */
+    public static function assertSubscriptionNotCreated($callback = null)
+    {
+        Event::assertNotDispatched(SubscriptionCreated::class, $callback);
+    }
+
+    /**
+     * Assert if the SubscriptionUpdated event was dispatched based on a truth-test callback.
+     *
+     * @param  callable|int|null  $callback
+     * @return void
+     */
+    public static function assertSubscriptionUpdated($callback = null)
+    {
+        Event::assertDispatched(SubscriptionUpdated::class, $callback);
+    }
+
+    /**
+     * Assert if the SubscriptionCancelled event was dispatched based on a truth-test callback.
+     *
+     * @param  callable|int|null  $callback
+     * @return void
+     */
+    public static function assertSubscriptionCancelled($callback = null)
+    {
+        Event::assertDispatched(SubscriptionCancelled::class, $callback);
+    }
+
+    /**
+     * Returns the default endpoints with their fake data.
+     *
+     * @return array
+     */
+    public static function initialEndpoints()
+    {
+        return [
+            static::PATH_PAYMENT_REFUND => [
+                'success' => true,
+                'response' => [
+                    'refund_request_id' => 12345,
+                ],
+            ],
+
+            static::PATH_SUBSCRIPTION_USERS => function () {
+                return [
+                    'success' => true,
+                    'response' => [
+                        [
+                            'subscription_id' => 3423423,
+                            'user_email' => 'john@example.com',
+                            'payment_information' => static::$paymentProvider === 'paypal'
+                                ? ['payment_method' => 'paypal']
+                                : [
+                                    'payment_method' => 'card',
+                                    'card_type' => 'visa',
+                                    'last_four_digits' => '1234',
+                                    'expiry_date' => '04/2022',
+                                ],
+                            'last_payment' => [
+                                'amount' => 0.00,
+                                'currency' => 'EUR',
+                                'date' => '',
+                            ],
+                        ]
+                    ]
+                ];
+            },
+
+            static::PATH_SUBSCRIPTION_MODIFIERS => [
+                'success' => true,
+                'response' => [
+                    [
+                        'modifier_id' => 6789,
+                        'sucscription_id' => 3423423,
+                        'amount' => 15.00,
+                        'currency' => 'EUR',
+                        'is_recurring' => false,
+                        'description' => 'This is a test modifier'
+                    ]
+                ]
+            ],
+
+            static::PATH_SUBSCRIPTION_MODIFIERS_CREATE => [
+                'success' => true,
+                'response' => [
+                    'subscription_id' => 3423423,
+                    'modifier_id' => 6789,
+                ],
+            ],
+
+            static::PATH_SUBSCRIPTION_MODIFIERS_DELETE => [
+                'success' => true
+            ],
+        ];
+    }
+
+    const API_VERSION = '2.0';
+    const PATH_PAYMENT_REFUND = 'payment/refund';
+    const PATH_SUBSCRIPTION_USERS = 'subscription/users';
+    const PATH_SUBSCRIPTION_MODIFIERS = 'subscription/modifiers';
+    const PATH_SUBSCRIPTION_MODIFIERS_CREATE = 'subscription/modifiers/create';
+    const PATH_SUBSCRIPTION_MODIFIERS_DELETE = 'subscription/modifiers/delete';
+}

--- a/src/CashierFake.php
+++ b/src/CashierFake.php
@@ -20,7 +20,7 @@ class CashierFake
      *
      * @var string
      */
-    public static $paymentProvider = 'card';
+    protected static $paymentProvider = 'card';
 
     /**
      * Initialize the fake instance

--- a/src/CashierFake.php
+++ b/src/CashierFake.php
@@ -16,14 +16,14 @@ use Laravel\Paddle\Events\SubscriptionUpdated;
 class CashierFake
 {
     /**
-     * The payment provider to mock the user as (either "paypal" or "card")
+     * The payment provider to mock the user as (either "paypal" or "card").
      *
      * @var string
      */
     protected static $paymentProvider = 'card';
 
     /**
-     * The card data to be returned by our mocked API calls
+     * The card data to be returned by our mocked API calls.
      *
      * @var array
      */
@@ -34,7 +34,7 @@ class CashierFake
     ];
 
     /**
-     * Initialize the fake instance
+     * Initialize the fake instance.
      *
      * @param  array  $endpoints
      * @param  string|array  $events
@@ -59,7 +59,7 @@ class CashierFake
     }
 
     /**
-     * Static constructor for syntactic sugar
+     * Static constructor for syntactic sugar.
      *
      * @return static
      */
@@ -69,7 +69,7 @@ class CashierFake
     }
 
     /**
-     * Mock the user as if they used PayPal as a payment provider
+     * Mock the user as if they used PayPal as a payment provider.
      *
      * @return self
      */
@@ -81,7 +81,7 @@ class CashierFake
     }
 
     /**
-     * Mock the user as if they used a credit card as a payment provider
+     * Mock the user as if they used a credit card as a payment provider.
      *
      * @return self
      */
@@ -171,7 +171,7 @@ class CashierFake
     }
 
     /**
-     * Format the given path into a full url
+     * Format the given path into a full url.
      *
      * @param  string  $path
      * @return string
@@ -184,7 +184,7 @@ class CashierFake
     }
 
     /**
-     * Mock a given endpoint with the provided response data
+     * Mock a given endpoint with the provided response data.
      *
      * @param  string  $endpoint
      * @param  mixed  $data
@@ -195,7 +195,7 @@ class CashierFake
         $response = is_array($data) ? Http::response($data) : $data;
 
         Http::fake([
-            static::retrieveEndpoint($endpoint) => $data
+            static::retrieveEndpoint($endpoint) => $data,
         ]);
     }
 
@@ -229,8 +229,8 @@ class CashierFake
                                 'currency' => 'EUR',
                                 'date' => '',
                             ],
-                        ]
-                    ]
+                        ],
+                    ],
                 ];
             },
 
@@ -244,8 +244,8 @@ class CashierFake
                         'currency' => 'EUR',
                         'is_recurring' => false,
                         'description' => 'This is a test modifier'
-                    ]
-                ]
+                    ],
+                ],
             ],
 
             static::PATH_SUBSCRIPTION_MODIFIERS_CREATE => [
@@ -257,7 +257,7 @@ class CashierFake
             ],
 
             static::PATH_SUBSCRIPTION_MODIFIERS_DELETE => [
-                'success' => true
+                'success' => true,
             ],
         ];
     }

--- a/src/CashierFake.php
+++ b/src/CashierFake.php
@@ -32,7 +32,7 @@ class CashierFake
     public function __construct(array $endpoints = [], $events = [])
     {
         // Merge user provided endpoints with our initial ones for mocking
-        foreach (array_merge($this->initialEndpoints(), $endpoints) as $endpoint => $data) {
+        foreach (array_merge($this->endpoints(), $endpoints) as $endpoint => $data) {
             $this->mockEndpoint($endpoint, $data);
         }
 
@@ -192,7 +192,7 @@ class CashierFake
      *
      * @return array
      */
-    protected function initialEndpoints()
+    protected function endpoints()
     {
         return [
             static::PATH_PAYMENT_REFUND => [

--- a/src/CashierFake.php
+++ b/src/CashierFake.php
@@ -3,15 +3,15 @@
 namespace Laravel\Paddle;
 
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Event;
 use Laravel\Paddle\Events\PaymentSucceeded;
-use Laravel\Paddle\Events\SubscriptionCancelled;
 use Laravel\Paddle\Events\SubscriptionCreated;
+use Laravel\Paddle\Events\SubscriptionUpdated;
+use Laravel\Paddle\Events\SubscriptionCancelled;
 use Laravel\Paddle\Events\SubscriptionPaymentFailed;
 use Laravel\Paddle\Events\SubscriptionPaymentSucceeded;
-use Laravel\Paddle\Events\SubscriptionUpdated;
 
 class CashierFake
 {
@@ -73,9 +73,7 @@ class CashierFake
      */
     public static function getFormattedVendorUrl(string $path): string
     {
-        return Cashier::vendorsUrl()
-               .'/api/2.0'
-               .Str::start($path, '/');
+        return Cashier::vendorsUrl().'/api/2.0'.Str::start($path, '/');
     }
 
     /**

--- a/src/CashierFake.php
+++ b/src/CashierFake.php
@@ -27,22 +27,22 @@ class CashierFake
      * @param array $endpoints
      * @return void
      */
-    public function __construct(array $endpoints = [])
+    public function __construct(array $endpoints = [], array $events = [])
     {
         // Merge user provided endpoints with our initial ones for mocking
         foreach (array_merge($this->initialEndpoints(), $endpoints) as $endpoint => $data) {
             $this->mockEndpoint($endpoint, $data);
         }
 
-        // Mock the given Cashier events
-        Event::fake([
+        // Merge user provided events and mock
+        Event::fake(array_merge([
             PaymentSucceeded::class,
             SubscriptionCreated::class,
             SubscriptionCancelled::class,
             SubscriptionPaymentFailed::class,
             SubscriptionPaymentSucceeded::class,
             SubscriptionUpdated::class,
-        ]);
+        ], $events));
     }
 
     /**

--- a/src/CashierFake.php
+++ b/src/CashierFake.php
@@ -243,7 +243,7 @@ class CashierFake
                         'amount' => 15.00,
                         'currency' => 'EUR',
                         'is_recurring' => false,
-                        'description' => 'This is a test modifier'
+                        'description' => 'This is a test modifier',
                     ],
                 ],
             ],

--- a/src/CashierFake.php
+++ b/src/CashierFake.php
@@ -2,18 +2,18 @@
 
 namespace Laravel\Paddle;
 
-use Illuminate\Support\Str;
-use Mockery\Generator\Method;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Event;
-use Laravel\Paddle\Events\WebhookHandled;
-use Laravel\Paddle\Events\WebhookReceived;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
 use Laravel\Paddle\Events\PaymentSucceeded;
-use Laravel\Paddle\Events\SubscriptionCreated;
-use Laravel\Paddle\Events\SubscriptionUpdated;
 use Laravel\Paddle\Events\SubscriptionCancelled;
+use Laravel\Paddle\Events\SubscriptionCreated;
 use Laravel\Paddle\Events\SubscriptionPaymentFailed;
 use Laravel\Paddle\Events\SubscriptionPaymentSucceeded;
+use Laravel\Paddle\Events\SubscriptionUpdated;
+use Laravel\Paddle\Events\WebhookHandled;
+use Laravel\Paddle\Events\WebhookReceived;
+use Mockery\Generator\Method;
 
 class CashierFake
 {

--- a/src/CashierFake.php
+++ b/src/CashierFake.php
@@ -180,7 +180,7 @@ class CashierFake
     public static function getFormattedVendorUrl(string $path): string
     {
         return Cashier::vendorsUrl()
-               .'/api/'.static::API_VERSION
+               .'/api/2.0'
                .Str::start($path, '/');
     }
 
@@ -192,14 +192,14 @@ class CashierFake
     protected function defaultVendorEndpoints()
     {
         return [
-            static::PATH_PAYMENT_REFUND => [
+            'payment/refund' => [
                 'success' => true,
                 'response' => [
                     'refund_request_id' => 12345,
                 ],
             ],
 
-            static::PATH_SUBSCRIPTION_USERS => function () {
+            'subscription/users' => function () {
                 return [
                     'success' => true,
                     'response' => [
@@ -217,7 +217,7 @@ class CashierFake
                 ];
             },
 
-            static::PATH_SUBSCRIPTION_MODIFIERS => [
+            'subscription/modifiers' => [
                 'success' => true,
                 'response' => [
                     [
@@ -231,7 +231,7 @@ class CashierFake
                 ],
             ],
 
-            static::PATH_SUBSCRIPTION_MODIFIERS_CREATE => [
+            'subscription/modifiers/create' => [
                 'success' => true,
                 'response' => [
                     'subscription_id' => 3423423,
@@ -239,16 +239,9 @@ class CashierFake
                 ],
             ],
 
-            static::PATH_SUBSCRIPTION_MODIFIERS_DELETE => [
+            'subscription/modifiers/delete' => [
                 'success' => true,
             ],
         ];
     }
-
-    const API_VERSION = '2.0';
-    const PATH_PAYMENT_REFUND = 'payment/refund';
-    const PATH_SUBSCRIPTION_USERS = 'subscription/users';
-    const PATH_SUBSCRIPTION_MODIFIERS = 'subscription/modifiers';
-    const PATH_SUBSCRIPTION_MODIFIERS_CREATE = 'subscription/modifiers/create';
-    const PATH_SUBSCRIPTION_MODIFIERS_DELETE = 'subscription/modifiers/delete';
 }

--- a/src/CashierFake.php
+++ b/src/CashierFake.php
@@ -81,7 +81,7 @@ class CashierFake
     }
 
     /**
-     * Set a response for the given endpoint
+     * Set the successful response for a given endpoint.
      *
      * @param  string  $endpoint
      * @param  mixed  $response
@@ -98,7 +98,7 @@ class CashierFake
     }
 
     /**
-     * Make the API given endpoint throw an error and attach an error
+     * Set an error response for a given endpoint.
      *
      * @param  string  $endpoint
      * @param  string  $message
@@ -107,7 +107,7 @@ class CashierFake
      *
      * @see https://developer.paddle.com/api-reference/ZG9jOjI1MzUzOTkw-api-error-codes
      */
-    public function error(string $endpoint, string $message = '', int $code = 0)
+    public function error(string $endpoint, $message = '', $code = 0)
     {
         $this->fakeHttpResponse($endpoint, [
             'success' => false,
@@ -118,9 +118,13 @@ class CashierFake
     }
 
     /**
-     * Fakes
+     * Fake the given endpoint with the provided response.
+     *
+     * @param  string  $endpoint
+     * @param  mixed  $response
+     * @return void
      */
-    protected function fakeHttpResponse($endpoint, $response)
+    protected function fakeHttpResponse(string $endpoint, $response)
     {
         $notFaked = ! Arr::exists($this->responses, $endpoint);
         $this->responses[$endpoint] = $response;

--- a/src/CashierFake.php
+++ b/src/CashierFake.php
@@ -40,7 +40,7 @@ class CashierFake
             }
 
             Http::fake([
-                static::getFormattedVendorUrl($endpoint) => array_merge(['success' => true], Arr::wrap($response))
+                static::getFormattedVendorUrl($endpoint) => array_merge(['success' => true], Arr::wrap($response)),
             ]);
         }
 

--- a/src/CashierFake.php
+++ b/src/CashierFake.php
@@ -11,9 +11,6 @@ use Laravel\Paddle\Events\SubscriptionCreated;
 use Laravel\Paddle\Events\SubscriptionPaymentFailed;
 use Laravel\Paddle\Events\SubscriptionPaymentSucceeded;
 use Laravel\Paddle\Events\SubscriptionUpdated;
-use Laravel\Paddle\Events\WebhookHandled;
-use Laravel\Paddle\Events\WebhookReceived;
-use Mockery\Generator\Method;
 
 class CashierFake
 {

--- a/src/CashierFake.php
+++ b/src/CashierFake.php
@@ -46,7 +46,9 @@ class CashierFake
                 $response = null;
             }
 
-            $this->fakeHttpResponse($endpoint, array_merge(['success' => true], Arr::wrap($response)));
+            $this->fakeHttpResponse($endpoint, array_merge([
+                'success' => true,
+            ], Arr::wrap($response)));
         }
 
         Event::fake(array_merge([
@@ -67,17 +69,6 @@ class CashierFake
     public static function fake(...$arguments)
     {
         return new static(...$arguments);
-    }
-
-    /**
-     * Format the given path into a full API url.
-     *
-     * @param  string  $path
-     * @return string
-     */
-    public static function getFormattedVendorUrl(string $path): string
-    {
-        return Cashier::vendorsUrl().'/api/2.0'.Str::start($path, '/');
     }
 
     /**
@@ -134,6 +125,17 @@ class CashierFake
                 return $this->responses[$endpoint];
             }]);
         }
+    }
+
+    /**
+     * Format the given path into a full API url.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public static function getFormattedVendorUrl(string $path): string
+    {
+        return Cashier::vendorsUrl().'/api/2.0'.Str::start($path, '/');
     }
 
     /**

--- a/src/CashierFake.php
+++ b/src/CashierFake.php
@@ -130,7 +130,9 @@ class CashierFake
         $this->responses[$endpoint] = $response;
 
         if ($notFaked) {
-            Http::fake([static::getFormattedVendorUrl($endpoint) => fn () => $this->responses[$endpoint]]);
+            Http::fake([static::getFormattedVendorUrl($endpoint) => function () use ($endpoint) {
+                return $this->responses[$endpoint];
+            }]);
         }
     }
 

--- a/src/CashierFake.php
+++ b/src/CashierFake.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Paddle;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
@@ -24,10 +25,11 @@ class CashierFake
     /**
      * Initialize the fake instance
      *
-     * @param array $endpoints
+     * @param array         $endpoints
+     * @param string|array  $events
      * @return void
      */
-    public function __construct(array $endpoints = [], array $events = [])
+    public function __construct(array $endpoints = [], $events = [])
     {
         // Merge user provided endpoints with our initial ones for mocking
         foreach (array_merge($this->initialEndpoints(), $endpoints) as $endpoint => $data) {
@@ -42,17 +44,17 @@ class CashierFake
             SubscriptionPaymentFailed::class,
             SubscriptionPaymentSucceeded::class,
             SubscriptionUpdated::class,
-        ], $events));
+        ], Arr::wrap($events)));
     }
 
     /**
-     * Syntactic sugar for the constructor
+     * Static constructor for syntactic sugar
      *
      * @return static
      */
-    public static function fake(array $endpoints = [])
+    public static function fake(...$arguments)
     {
-        return new static($endpoints);
+        return new static(...$arguments);
     }
 
     /**
@@ -178,7 +180,7 @@ class CashierFake
      */
     protected function mockEndpoint(string $endpoint, $data = [])
     {
-        $response = ! is_callable($data) ? Http::response($data) : $data;
+        $response = is_array($data) ? Http::response($data) : $data;
 
         Http::fake([
             static::retrieveEndpoint($endpoint) => $data

--- a/src/CashierFake.php
+++ b/src/CashierFake.php
@@ -22,6 +22,11 @@ class CashierFake
      */
     protected static $paymentProvider = 'card';
 
+    /**
+     * The card data to be returned by our mocked API calls
+     *
+     * @var array
+     */
     protected static $cardData = [
         'card_type' => 'visa',
         'last_four_digits' => '1234',
@@ -31,8 +36,8 @@ class CashierFake
     /**
      * Initialize the fake instance
      *
-     * @param array         $endpoints
-     * @param string|array  $events
+     * @param  array  $endpoints
+     * @param  string|array  $events
      * @return void
      */
     public function __construct(array $endpoints = [], $events = [])
@@ -168,7 +173,7 @@ class CashierFake
     /**
      * Format the given path into a full url
      *
-     * @param string $path
+     * @param  string  $path
      * @return string
      */
     public static function retrieveEndpoint(string $path): string
@@ -181,8 +186,8 @@ class CashierFake
     /**
      * Mock a given endpoint with the provided response data
      *
-     * @param string $endpoint
-     * @param mixed  $data
+     * @param  string  $endpoint
+     * @param  mixed  $data
      * @return void
      */
     protected function mockEndpoint(string $endpoint, $data = [])

--- a/src/CashierFake.php
+++ b/src/CashierFake.php
@@ -3,15 +3,15 @@
 namespace Laravel\Paddle;
 
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
 use Laravel\Paddle\Events\PaymentSucceeded;
-use Laravel\Paddle\Events\SubscriptionCreated;
-use Laravel\Paddle\Events\SubscriptionUpdated;
 use Laravel\Paddle\Events\SubscriptionCancelled;
+use Laravel\Paddle\Events\SubscriptionCreated;
 use Laravel\Paddle\Events\SubscriptionPaymentFailed;
 use Laravel\Paddle\Events\SubscriptionPaymentSucceeded;
+use Laravel\Paddle\Events\SubscriptionUpdated;
 
 class CashierFake
 {

--- a/tests/Feature/ChargesTest.php
+++ b/tests/Feature/ChargesTest.php
@@ -36,6 +36,7 @@ class ChargesTest extends FeatureTestCase
     {
         Cashier::fake([
             'payment/refund' => [
+                'success' => true,
                 'response' => [
                     'refund_request_id' => 12345,
                 ],

--- a/tests/Feature/ChargesTest.php
+++ b/tests/Feature/ChargesTest.php
@@ -39,8 +39,8 @@ class ChargesTest extends FeatureTestCase
                 'success' => true,
                 'response' => [
                     'refund_request_id' => 12345,
-                ]
-            ]
+                ],
+            ],
         ]);
 
         $billable = $this->createBillable();

--- a/tests/Feature/ChargesTest.php
+++ b/tests/Feature/ChargesTest.php
@@ -34,9 +34,17 @@ class ChargesTest extends FeatureTestCase
 
     public function test_payments_can_be_refunded()
     {
+        Cashier::fake([
+            'payment/refund' => [
+                'success' => true,
+                'response' => [
+                    'refund_request_id' => 12345,
+                ]
+            ]
+        ]);
+
         $billable = $this->createBillable();
 
-        Cashier::fake();
 
         $response = $billable->refund(4321, 12.50, 'Incorrect order');
 

--- a/tests/Feature/ChargesTest.php
+++ b/tests/Feature/ChargesTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use Laravel\Paddle\Cashier;
 use Illuminate\Support\Facades\Http;
 
 class ChargesTest extends FeatureTestCase
@@ -36,14 +37,7 @@ class ChargesTest extends FeatureTestCase
     {
         $billable = $this->createBillable();
 
-        Http::fake([
-            'vendors.paddle.com/api/2.0/payment/refund' => Http::response([
-                'success' => true,
-                'response' => [
-                    'refund_request_id' => 12345,
-                ],
-            ]),
-        ]);
+        Cashier::fake();
 
         $response = $billable->refund(4321, 12.50, 'Incorrect order');
 

--- a/tests/Feature/ChargesTest.php
+++ b/tests/Feature/ChargesTest.php
@@ -36,7 +36,6 @@ class ChargesTest extends FeatureTestCase
     {
         Cashier::fake([
             'payment/refund' => [
-                'success' => true,
                 'response' => [
                     'refund_request_id' => 12345,
                 ],

--- a/tests/Feature/ChargesTest.php
+++ b/tests/Feature/ChargesTest.php
@@ -45,7 +45,6 @@ class ChargesTest extends FeatureTestCase
 
         $billable = $this->createBillable();
 
-
         $response = $billable->refund(4321, 12.50, 'Incorrect order');
 
         $this->assertSame(12345, $response);

--- a/tests/Feature/ChargesTest.php
+++ b/tests/Feature/ChargesTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature;
 
-use Laravel\Paddle\Cashier;
 use Illuminate\Support\Facades\Http;
+use Laravel\Paddle\Cashier;
 
 class ChargesTest extends FeatureTestCase
 {

--- a/tests/Feature/ChargesTest.php
+++ b/tests/Feature/ChargesTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Support\Facades\Http;
 use Laravel\Paddle\Cashier;
 
 class ChargesTest extends FeatureTestCase

--- a/tests/Feature/ModifiersTest.php
+++ b/tests/Feature/ModifiersTest.php
@@ -2,30 +2,17 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Support\Facades\Http;
+use Money\Currency;
+use Laravel\Paddle\Cashier;
 use Laravel\Paddle\Modifier;
 use Laravel\Paddle\Subscription;
-use Money\Currency;
+use Illuminate\Support\Facades\Http;
 
 class ModifiersTest extends FeatureTestCase
 {
     public function test_subscriptions_can_return_their_modifiers()
     {
-        Http::fake([
-            'https://vendors.paddle.com/api/2.0/subscription/modifiers' => Http::response([
-                'success' => true,
-                'response' => [
-                    [
-                        'modifier_id' => 6789,
-                        'subscription_id' => 3423423,
-                        'amount' => 15.00,
-                        'currency' => 'EUR',
-                        'is_recurring' => false,
-                        'description' => 'This is a test modifier',
-                    ],
-                ],
-            ]),
-        ]);
+        Cashier::fake();
 
         $billable = $this->createBillable('taylor');
 
@@ -60,28 +47,7 @@ class ModifiersTest extends FeatureTestCase
 
     public function test_subscriptions_can_create_modifiers()
     {
-        Http::fake([
-            'https://vendors.paddle.com/api/2.0/subscription/users' => Http::response([
-                'success' => true,
-                'response' => [
-                    [
-                        'last_payment' => [
-                            'amount' => 0.00,
-                            'currency' => 'EUR',
-                            'date' => '',
-                        ],
-                    ],
-                ],
-            ]),
-
-            'https://vendors.paddle.com/api/2.0/subscription/modifiers/create' => Http::response([
-                'success' => true,
-                'response' => [
-                    'subscription_id' => 3423423,
-                    'modifier_id' => 6789,
-                ],
-            ]),
-        ]);
+        Cashier::fake();
 
         $billable = $this->createBillable('taylor');
 
@@ -122,11 +88,7 @@ class ModifiersTest extends FeatureTestCase
 
     public function test_a_modifier_can_delete_itself()
     {
-        Http::fake([
-            'https://vendors.paddle.com/api/2.0/subscription/modifiers/delete' => Http::response([
-                'success' => true,
-            ]),
-        ]);
+        Cashier::fake();
 
         $billable = $this->createBillable('taylor');
 

--- a/tests/Feature/ModifiersTest.php
+++ b/tests/Feature/ModifiersTest.php
@@ -14,6 +14,7 @@ class ModifiersTest extends FeatureTestCase
     {
         Cashier::fake([
             'subscription/modifiers' => [
+                'success' => true,
                 'response' => [[
                     'modifier_id' => 6789,
                     'sucscription_id' => 3423423,
@@ -58,25 +59,18 @@ class ModifiersTest extends FeatureTestCase
 
     public function test_subscriptions_can_create_modifiers()
     {
-        Cashier::fake([
-            'subscription/users' => [
-                'response' => [
-                    [
-                        'last_payment' => [
-                            'amount' => 0.00,
-                            'currency' => 'EUR',
-                            'date' => '',
-                        ],
-                    ],
-                ],
-            ],
-            'subscription/modifiers/create' => [
-                'response' => [
-                    'subscription_id' => 3423423,
-                    'modifier_id' => 6789,
-                ],
-            ],
-        ]);
+        Cashier::fake()
+            ->response('subscription/users', [[
+                'last_payment' => [
+                    'amount' => 0.00,
+                    'currency' => 'EUR',
+                    'date' => '',
+                ]
+            ]])
+            ->response('subscription/modifiers/create', [
+                'subscription_id' => 3423423,
+                'modifier_id' => 6789,
+            ]);
 
         $billable = $this->createBillable('taylor');
 

--- a/tests/Feature/ModifiersTest.php
+++ b/tests/Feature/ModifiersTest.php
@@ -21,8 +21,8 @@ class ModifiersTest extends FeatureTestCase
                     'currency' => 'EUR',
                     'is_recurring' => false,
                     'description' => 'This is a test modifier',
-                ]]
-            ]
+                ]],
+            ],
         ]);
 
         $billable = $this->createBillable('taylor');
@@ -68,14 +68,14 @@ class ModifiersTest extends FeatureTestCase
                             'date' => '',
                         ],
                     ],
-                ]
+                ],
             ],
             'subscription/modifiers/create' => [
                 'response' => [
                     'subscription_id' => 3423423,
                     'modifier_id' => 6789,
-                ]
-            ]
+                ],
+            ],
         ]);
 
         $billable = $this->createBillable('taylor');

--- a/tests/Feature/ModifiersTest.php
+++ b/tests/Feature/ModifiersTest.php
@@ -65,7 +65,7 @@ class ModifiersTest extends FeatureTestCase
                     'amount' => 0.00,
                     'currency' => 'EUR',
                     'date' => '',
-                ]
+                ],
             ]])
             ->response('subscription/modifiers/create', [
                 'subscription_id' => 3423423,

--- a/tests/Feature/ModifiersTest.php
+++ b/tests/Feature/ModifiersTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Feature;
 
-use Money\Currency;
+use Illuminate\Support\Facades\Http;
 use Laravel\Paddle\Cashier;
 use Laravel\Paddle\Modifier;
 use Laravel\Paddle\Subscription;
-use Illuminate\Support\Facades\Http;
+use Money\Currency;
 
 class ModifiersTest extends FeatureTestCase
 {

--- a/tests/Feature/ModifiersTest.php
+++ b/tests/Feature/ModifiersTest.php
@@ -12,19 +12,14 @@ class ModifiersTest extends FeatureTestCase
 {
     public function test_subscriptions_can_return_their_modifiers()
     {
-        Cashier::fake([
-            'subscription/modifiers' => [
-                'success' => true,
-                'response' => [[
-                    'modifier_id' => 6789,
-                    'sucscription_id' => 3423423,
-                    'amount' => 15.00,
-                    'currency' => 'EUR',
-                    'is_recurring' => false,
-                    'description' => 'This is a test modifier',
-                ]],
-            ],
-        ]);
+        Cashier::fake()->response('subscription/modifiers', [[
+            'modifier_id' => 6789,
+            'sucscription_id' => 3423423,
+            'amount' => 15.00,
+            'currency' => 'EUR',
+            'is_recurring' => false,
+            'description' => 'This is a test modifier',
+        ]]);
 
         $billable = $this->createBillable('taylor');
 

--- a/tests/Feature/ModifiersTest.php
+++ b/tests/Feature/ModifiersTest.php
@@ -12,7 +12,18 @@ class ModifiersTest extends FeatureTestCase
 {
     public function test_subscriptions_can_return_their_modifiers()
     {
-        Cashier::fake();
+        Cashier::fake([
+            'subscription/modifiers' => [
+                'response' => [[
+                    'modifier_id' => 6789,
+                    'sucscription_id' => 3423423,
+                    'amount' => 15.00,
+                    'currency' => 'EUR',
+                    'is_recurring' => false,
+                    'description' => 'This is a test modifier',
+                ]]
+            ]
+        ]);
 
         $billable = $this->createBillable('taylor');
 
@@ -47,7 +58,25 @@ class ModifiersTest extends FeatureTestCase
 
     public function test_subscriptions_can_create_modifiers()
     {
-        Cashier::fake();
+        Cashier::fake([
+            'subscription/users' => [
+                'response' => [
+                    [
+                        'last_payment' => [
+                            'amount' => 0.00,
+                            'currency' => 'EUR',
+                            'date' => '',
+                        ],
+                    ],
+                ]
+            ],
+            'subscription/modifiers/create' => [
+                'response' => [
+                    'subscription_id' => 3423423,
+                    'modifier_id' => 6789,
+                ]
+            ]
+        ]);
 
         $billable = $this->createBillable('taylor');
 

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -187,22 +187,16 @@ class SubscriptionsTest extends FeatureTestCase
 
     public function test_subscriptions_can_retrieve_their_payment_info()
     {
-        Cashier::fake([
-            'subscription/users' => [
-                'response' => [
-                    [
-                        'subscription_id' => 3423423,
-                        'user_email' => 'john@example.com',
-                        'payment_information' => [
-                            'payment_method' => 'card',
-                            'card_type' => 'visa',
-                            'last_four_digits' => '1234',
-                            'expiry_date' => '04/2022',
-                        ],
-                    ],
-                ],
+        Cashier::fake()->response('subscription/users', [[
+            'subscription_id' => 3423423,
+            'user_email' => 'john@example.com',
+            'payment_information' => [
+                'payment_method' => 'card',
+                'card_type' => 'visa',
+                'last_four_digits' => '1234',
+                'expiry_date' => '04/2022',
             ],
-        ]);
+        ]]);
 
         $billable = $this->createBillable('taylor');
 
@@ -223,19 +217,13 @@ class SubscriptionsTest extends FeatureTestCase
 
     public function test_subscriptions_can_retrieve_their_payment_info_for_paypal()
     {
-        Cashier::fake([
-            'subscription/users' => [
-                'response' => [
-                    [
-                        'subscription_id' => 3423423,
-                        'user_email' => 'john@example.com',
-                        'payment_information' => [
-                            'payment_method' => 'paypal',
-                        ],
-                    ],
-                ],
+        Cashier::fake()->response('subscription/users', [[
+            'subscription_id' => 3423423,
+            'user_email' => 'john@example.com',
+            'payment_information' => [
+                'payment_method' => 'paypal',
             ],
-        ]);
+        ]]);
 
         $billable = $this->createBillable('taylor');
 

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -3,9 +3,10 @@
 namespace Tests\Feature;
 
 use Carbon\Carbon;
-use Illuminate\Support\Facades\Http;
-use Laravel\Paddle\Subscription;
 use LogicException;
+use Laravel\Paddle\Cashier;
+use Laravel\Paddle\Subscription;
+use Illuminate\Support\Facades\Http;
 
 class SubscriptionsTest extends FeatureTestCase
 {
@@ -187,23 +188,7 @@ class SubscriptionsTest extends FeatureTestCase
 
     public function test_subscriptions_can_retrieve_their_payment_info()
     {
-        Http::fake([
-            'https://vendors.paddle.com/api/2.0/subscription/users' => Http::response([
-                'success' => true,
-                'response' => [
-                    [
-                        'subscription_id' => 3423423,
-                        'user_email' => 'john@example.com',
-                        'payment_information' => [
-                            'payment_method' => 'card',
-                            'card_type' => 'visa',
-                            'last_four_digits' => '1234',
-                            'expiry_date' => '04/2022',
-                        ],
-                    ],
-                ],
-            ]),
-        ]);
+        Cashier::fake()->card();
 
         $billable = $this->createBillable('taylor');
 
@@ -224,20 +209,7 @@ class SubscriptionsTest extends FeatureTestCase
 
     public function test_subscriptions_can_retrieve_their_payment_info_for_paypal()
     {
-        Http::fake([
-            'https://vendors.paddle.com/api/2.0/subscription/users' => Http::response([
-                'success' => true,
-                'response' => [
-                    [
-                        'subscription_id' => 3423423,
-                        'user_email' => 'john@example.com',
-                        'payment_information' => [
-                            'payment_method' => 'paypal',
-                        ],
-                    ],
-                ],
-            ]),
-        ]);
+        Cashier::fake()->paypal();
 
         $billable = $this->createBillable('taylor');
 

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -201,7 +201,7 @@ class SubscriptionsTest extends FeatureTestCase
                         ],
                     ],
                 ],
-            ]
+            ],
         ]);
 
         $billable = $this->createBillable('taylor');
@@ -234,7 +234,7 @@ class SubscriptionsTest extends FeatureTestCase
                         ],
                     ],
                 ],
-            ]
+            ],
         ]);
 
         $billable = $this->createBillable('taylor');

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -188,7 +188,11 @@ class SubscriptionsTest extends FeatureTestCase
 
     public function test_subscriptions_can_retrieve_their_payment_info()
     {
-        Cashier::fake()->card();
+        Cashier::fake()->card([
+            'card_type' => $brand = 'visa',
+            'last_four_digits' => $last4 = '1234',
+            'expiry_date' => $expiry = '04/2022',
+        ]);
 
         $billable = $this->createBillable('taylor');
 
@@ -202,9 +206,9 @@ class SubscriptionsTest extends FeatureTestCase
 
         $this->assertSame('john@example.com', $subscription->paddleEmail());
         $this->assertSame('card', $subscription->paymentMethod());
-        $this->assertSame('visa', $subscription->cardBrand());
-        $this->assertSame('1234', $subscription->cardLastFour());
-        $this->assertSame('04/2022', $subscription->cardExpirationDate());
+        $this->assertSame($brand, $subscription->cardBrand());
+        $this->assertSame($last4, $subscription->cardLastFour());
+        $this->assertSame($expiry, $subscription->cardExpirationDate());
     }
 
     public function test_subscriptions_can_retrieve_their_payment_info_for_paypal()

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -3,10 +3,10 @@
 namespace Tests\Feature;
 
 use Carbon\Carbon;
-use LogicException;
+use Illuminate\Support\Facades\Http;
 use Laravel\Paddle\Cashier;
 use Laravel\Paddle\Subscription;
-use Illuminate\Support\Facades\Http;
+use LogicException;
 
 class SubscriptionsTest extends FeatureTestCase
 {

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -187,10 +187,21 @@ class SubscriptionsTest extends FeatureTestCase
 
     public function test_subscriptions_can_retrieve_their_payment_info()
     {
-        Cashier::fake()->card([
-            'card_type' => $brand = 'visa',
-            'last_four_digits' => $last4 = '1234',
-            'expiry_date' => $expiry = '04/2022',
+        Cashier::fake([
+            'subscription/users' => [
+                'response' => [
+                    [
+                        'subscription_id' => 3423423,
+                        'user_email' => 'john@example.com',
+                        'payment_information' => [
+                            'payment_method' => 'card',
+                            'card_type' => 'visa',
+                            'last_four_digits' => '1234',
+                            'expiry_date' => '04/2022',
+                        ],
+                    ],
+                ],
+            ]
         ]);
 
         $billable = $this->createBillable('taylor');
@@ -205,14 +216,26 @@ class SubscriptionsTest extends FeatureTestCase
 
         $this->assertSame('john@example.com', $subscription->paddleEmail());
         $this->assertSame('card', $subscription->paymentMethod());
-        $this->assertSame($brand, $subscription->cardBrand());
-        $this->assertSame($last4, $subscription->cardLastFour());
-        $this->assertSame($expiry, $subscription->cardExpirationDate());
+        $this->assertSame('visa', $subscription->cardBrand());
+        $this->assertSame('1234', $subscription->cardLastFour());
+        $this->assertSame('04/2022', $subscription->cardExpirationDate());
     }
 
     public function test_subscriptions_can_retrieve_their_payment_info_for_paypal()
     {
-        Cashier::fake()->paypal();
+        Cashier::fake([
+            'subscription/users' => [
+                'response' => [
+                    [
+                        'subscription_id' => 3423423,
+                        'user_email' => 'john@example.com',
+                        'payment_information' => [
+                            'payment_method' => 'paypal',
+                        ],
+                    ],
+                ],
+            ]
+        ]);
 
         $billable = $this->createBillable('taylor');
 

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use Carbon\Carbon;
-use Illuminate\Support\Facades\Http;
 use Laravel\Paddle\Cashier;
 use Laravel\Paddle\Subscription;
 use LogicException;

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -3,12 +3,12 @@
 namespace Tests\Feature;
 
 use Laravel\Paddle\Cashier;
-use Laravel\Paddle\Subscription;
 use Laravel\Paddle\Events\PaymentSucceeded;
-use Laravel\Paddle\Events\SubscriptionCreated;
-use Laravel\Paddle\Events\SubscriptionUpdated;
 use Laravel\Paddle\Events\SubscriptionCancelled;
+use Laravel\Paddle\Events\SubscriptionCreated;
 use Laravel\Paddle\Events\SubscriptionPaymentSucceeded;
+use Laravel\Paddle\Events\SubscriptionUpdated;
+use Laravel\Paddle\Subscription;
 
 class WebhooksTest extends FeatureTestCase
 {

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -2,13 +2,13 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Support\Facades\Event;
-use Laravel\Paddle\Events\PaymentSucceeded;
-use Laravel\Paddle\Events\SubscriptionCancelled;
-use Laravel\Paddle\Events\SubscriptionCreated;
-use Laravel\Paddle\Events\SubscriptionPaymentSucceeded;
-use Laravel\Paddle\Events\SubscriptionUpdated;
+use Laravel\Paddle\Cashier;
 use Laravel\Paddle\Subscription;
+use Laravel\Paddle\Events\PaymentSucceeded;
+use Laravel\Paddle\Events\SubscriptionCreated;
+use Laravel\Paddle\Events\SubscriptionUpdated;
+use Laravel\Paddle\Events\SubscriptionCancelled;
+use Laravel\Paddle\Events\SubscriptionPaymentSucceeded;
 
 class WebhooksTest extends FeatureTestCase
 {
@@ -21,7 +21,7 @@ class WebhooksTest extends FeatureTestCase
 
     public function test_it_can_handle_a_payment_succeeded_event()
     {
-        Event::fake();
+        Cashier::fake();
 
         $user = $this->createUser();
 
@@ -61,14 +61,14 @@ class WebhooksTest extends FeatureTestCase
             'receipt_url' => 'https://example.com/receipt.pdf',
         ]);
 
-        Event::assertDispatched(PaymentSucceeded::class, function (PaymentSucceeded $event) use ($user) {
+        Cashier::assertPaymentSucceeded(function (PaymentSucceeded $event) use ($user) {
             return $event->billable->id === $user->id && $event->receipt->order_id === 'foo';
         });
     }
 
     public function test_it_can_handle_a_payment_succeeded_event_when_billable_already_exists()
     {
-        Event::fake();
+        Cashier::fake();
 
         $user = $this->createBillable('taylor', [
             'trial_ends_at' => now('UTC')->addDays(5),
@@ -110,14 +110,14 @@ class WebhooksTest extends FeatureTestCase
             'receipt_url' => 'https://example.com/receipt.pdf',
         ]);
 
-        Event::assertDispatched(PaymentSucceeded::class, function (PaymentSucceeded $event) use ($user) {
+        Cashier::assertPaymentSucceeded(function (PaymentSucceeded $event) use ($user) {
             return $event->billable->id === $user->id && $event->receipt->order_id === 'foo';
         });
     }
 
     public function test_it_can_handle_a_subscription_payment_succeeded_event()
     {
-        Event::fake();
+        Cashier::fake();
 
         $user = $this->createBillable();
 
@@ -166,14 +166,14 @@ class WebhooksTest extends FeatureTestCase
             'receipt_url' => 'https://example.com/receipt.pdf',
         ]);
 
-        Event::assertDispatched(SubscriptionPaymentSucceeded::class, function (SubscriptionPaymentSucceeded $event) use ($user) {
+        Cashier::assertSubscriptionPaymentSucceeded(function (SubscriptionPaymentSucceeded $event) use ($user) {
             return $event->billable->id === $user->id && $event->receipt->order_id === 'foo';
         });
     }
 
     public function test_it_can_handle_a_subscription_created_event()
     {
-        Event::fake();
+        Cashier::fake();
 
         $user = $this->createUser();
 
@@ -208,14 +208,14 @@ class WebhooksTest extends FeatureTestCase
             'trial_ends_at' => null,
         ]);
 
-        Event::assertDispatched(SubscriptionCreated::class, function (SubscriptionCreated $event) use ($user) {
+        Cashier::assertSubscriptionCreated(function (SubscriptionCreated $event) use ($user) {
             return $event->billable->id === $user->id && $event->subscription->paddle_plan === 1234;
         });
     }
 
     public function test_it_can_handle_a_subscription_created_event_if_billable_already_exists()
     {
-        Event::fake();
+        Cashier::fake();
 
         $user = $this->createUser();
         $user->customer()->create([
@@ -253,14 +253,14 @@ class WebhooksTest extends FeatureTestCase
             'trial_ends_at' => null,
         ]);
 
-        Event::assertDispatched(SubscriptionCreated::class, function (SubscriptionCreated $event) use ($user) {
+        Cashier::assertSubscriptionCreated(function (SubscriptionCreated $event) use ($user) {
             return $event->billable->id === $user->id && $event->subscription->paddle_plan === 1234;
         });
     }
 
     public function test_it_can_handle_a_subscription_updated_event()
     {
-        Event::fake();
+        Cashier::fake();
 
         $billable = $this->createBillable('taylor');
 
@@ -293,14 +293,14 @@ class WebhooksTest extends FeatureTestCase
             'paused_from' => $date,
         ]);
 
-        Event::assertDispatched(SubscriptionUpdated::class, function (SubscriptionUpdated $event) {
+        Cashier::assertSubscriptionUpdated(function (SubscriptionUpdated $event) {
             return $event->subscription->paddle_plan === 1234;
         });
     }
 
     public function test_it_can_handle_a_subscription_cancelled_event()
     {
-        Event::fake();
+        Cashier::fake();
 
         $billable = $this->createBillable('taylor');
 
@@ -330,14 +330,14 @@ class WebhooksTest extends FeatureTestCase
             'ends_at' => $date,
         ]);
 
-        Event::assertDispatched(SubscriptionCancelled::class, function (SubscriptionCancelled $event) {
+        Cashier::assertSubscriptionCancelled(function (SubscriptionCancelled $event) {
             return $event->subscription->paddle_plan === 2323;
         });
     }
 
     public function test_manual_created_paylinks_without_passthrough_values_are_ignored()
     {
-        Event::fake();
+        Cashier::fake();
 
         $user = $this->createUser();
 
@@ -368,6 +368,6 @@ class WebhooksTest extends FeatureTestCase
             'trial_ends_at' => null,
         ]);
 
-        Event::assertNotDispatched(SubscriptionCreated::class);
+        Cashier::assertSubscriptionNotCreated();
     }
 }

--- a/tests/Unit/CashierFakeTest.php
+++ b/tests/Unit/CashierFakeTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Unit;
 
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Laravel\Paddle\Cashier;
 use Laravel\Paddle\CashierFake;
@@ -9,7 +11,7 @@ use Tests\TestCase;
 
 class CashierFakeTest extends TestCase
 {
-    public function test_a_user_may_overwrite_its_responses()
+    public function test_a_user_may_overwrite_its_api_responses()
     {
         Cashier::fake([
             CashierFake::PATH_PAYMENT_REFUND => $expected = ['fake' => 'response'],
@@ -20,4 +22,23 @@ class CashierFakeTest extends TestCase
             Http::get(CashierFake::retrieveEndpoint(CashierFake::PATH_PAYMENT_REFUND))->body()
         );
     }
+
+    public function test_a_user_may_append_additional_events_to_mock()
+    {
+        Cashier::fake(events: [CapturedTestEvent::class]);
+
+        event(new CapturedTestEvent);
+        event(new UncapturedTestEvent);
+
+        Event::assertDispatched(CapturedTestEvent::class);
+        Event::assertNotDispatched(UncapturedTestEvent::class);
+    }
+}
+
+class CapturedTestEvent
+{
+}
+
+class UncapturedTestEvent
+{
 }

--- a/tests/Unit/CashierFakeTest.php
+++ b/tests/Unit/CashierFakeTest.php
@@ -14,7 +14,7 @@ class CashierFakeTest extends TestCase
     public function test_a_user_may_overwrite_its_api_responses()
     {
         Cashier::fake([
-            'payment/refund' => $expected = ['fake' => 'response'],
+            'payment/refund' => $expected = ['success' => true, 'response' => ['faked' => 'response']],
         ]);
 
         $this->assertEquals(
@@ -32,15 +32,6 @@ class CashierFakeTest extends TestCase
 
         Event::assertDispatched(CapturedTestEvent::class);
         Event::assertNotDispatched(UncapturedTestEvent::class);
-    }
-
-    public function test_a_user_may_overwrite_the_standard_card_data()
-    {
-        Cashier::fake()->card([$key = 'last_four_digits' => $expected = '9876']);
-
-        $response = Http::get(CashierFake::getFormattedVendorUrl('subscription/users'))->json();
-
-        $this->assertEquals($expected, Arr::get($response, 'response.0.payment_information.'.$key));
     }
 }
 

--- a/tests/Unit/CashierFakeTest.php
+++ b/tests/Unit/CashierFakeTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Support\Facades\Http;
+use Laravel\Paddle\Cashier;
+use Laravel\Paddle\CashierFake;
+use Tests\TestCase;
+
+class CashierFakeTest extends TestCase
+{
+    public function test_a_user_may_overwrite_its_responses()
+    {
+        Cashier::fake([
+            CashierFake::PATH_PAYMENT_REFUND => $expected = ['fake' => 'response'],
+        ]);
+
+        $this->assertEquals(
+            json_encode($expected),
+            Http::get(CashierFake::retrieveEndpoint(CashierFake::PATH_PAYMENT_REFUND))->body()
+        );
+    }
+}

--- a/tests/Unit/CashierFakeTest.php
+++ b/tests/Unit/CashierFakeTest.php
@@ -19,7 +19,7 @@ class CashierFakeTest extends TestCase
 
         $this->assertEquals(
             $expected,
-            Http::get(CashierFake::retrieveEndpoint(CashierFake::PATH_PAYMENT_REFUND))->json()
+            Http::get(CashierFake::getFormattedVendorUrl(CashierFake::PATH_PAYMENT_REFUND))->json()
         );
     }
 
@@ -38,7 +38,7 @@ class CashierFakeTest extends TestCase
     {
         Cashier::fake()->card([$key = 'last_four_digits' => $expected = '9876']);
 
-        $response = Http::get(CashierFake::retrieveEndpoint(CashierFake::PATH_SUBSCRIPTION_USERS))->json();
+        $response = Http::get(CashierFake::getFormattedVendorUrl(CashierFake::PATH_SUBSCRIPTION_USERS))->json();
 
         $this->assertEquals($expected, Arr::get($response, 'response.0.payment_information.'.$key));
     }

--- a/tests/Unit/CashierFakeTest.php
+++ b/tests/Unit/CashierFakeTest.php
@@ -25,7 +25,7 @@ class CashierFakeTest extends TestCase
 
     public function test_a_user_may_append_additional_events_to_mock()
     {
-        Cashier::fake(events: [CapturedTestEvent::class]);
+        Cashier::fake([], [CapturedTestEvent::class]);
 
         event(new CapturedTestEvent);
         event(new UncapturedTestEvent);

--- a/tests/Unit/CashierFakeTest.php
+++ b/tests/Unit/CashierFakeTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Unit;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Laravel\Paddle\Cashier;

--- a/tests/Unit/CashierFakeTest.php
+++ b/tests/Unit/CashierFakeTest.php
@@ -8,7 +8,6 @@ use Laravel\Paddle\Cashier;
 use Laravel\Paddle\CashierFake;
 use Laravel\Paddle\Exceptions\PaddleException;
 use Tests\Feature\FeatureTestCase;
-use Tests\TestCase;
 
 class CashierFakeTest extends FeatureTestCase
 {

--- a/tests/Unit/CashierFakeTest.php
+++ b/tests/Unit/CashierFakeTest.php
@@ -14,12 +14,12 @@ class CashierFakeTest extends TestCase
     public function test_a_user_may_overwrite_its_api_responses()
     {
         Cashier::fake([
-            CashierFake::PATH_PAYMENT_REFUND => $expected = ['fake' => 'response'],
+            'payment/refund' => $expected = ['fake' => 'response'],
         ]);
 
         $this->assertEquals(
             $expected,
-            Http::get(CashierFake::getFormattedVendorUrl(CashierFake::PATH_PAYMENT_REFUND))->json()
+            Http::get(CashierFake::getFormattedVendorUrl('payment/refund'))->json()
         );
     }
 
@@ -38,7 +38,7 @@ class CashierFakeTest extends TestCase
     {
         Cashier::fake()->card([$key = 'last_four_digits' => $expected = '9876']);
 
-        $response = Http::get(CashierFake::getFormattedVendorUrl(CashierFake::PATH_SUBSCRIPTION_USERS))->json();
+        $response = Http::get(CashierFake::getFormattedVendorUrl('subscription/users'))->json();
 
         $this->assertEquals($expected, Arr::get($response, 'response.0.payment_information.'.$key));
     }

--- a/tests/Unit/CashierFakeTest.php
+++ b/tests/Unit/CashierFakeTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Unit;
 
-use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;

--- a/tests/Unit/CashierFakeTest.php
+++ b/tests/Unit/CashierFakeTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Laravel\Paddle\Cashier;
@@ -18,8 +19,8 @@ class CashierFakeTest extends TestCase
         ]);
 
         $this->assertEquals(
-            json_encode($expected),
-            Http::get(CashierFake::retrieveEndpoint(CashierFake::PATH_PAYMENT_REFUND))->body()
+            $expected,
+            Http::get(CashierFake::retrieveEndpoint(CashierFake::PATH_PAYMENT_REFUND))->json()
         );
     }
 
@@ -32,6 +33,15 @@ class CashierFakeTest extends TestCase
 
         Event::assertDispatched(CapturedTestEvent::class);
         Event::assertNotDispatched(UncapturedTestEvent::class);
+    }
+
+    public function test_a_user_may_overwrite_the_standard_card_data()
+    {
+        Cashier::fake()->card([$key = 'last_four_digits' => $expected = '9876']);
+
+        $response = Http::get(CashierFake::retrieveEndpoint(CashierFake::PATH_SUBSCRIPTION_USERS))->json();
+
+        $this->assertEquals($expected, Arr::get($response, 'response.0.payment_information.'.$key));
     }
 }
 


### PR DESCRIPTION
# Overview
This PR adds a way for users to easily fake events and API calls with a single command and a couple options for customizing the responses and asserting that certain events are dispatched.

# How it works
Under the hood, `Cashier::fake()` creates a new instance of `CashierFake` which, upon creation, fakes API calls with `Http::fake()` and Cashier-provided events as well with `Event::fake()`. A user may customize this experience if they wish to override the defaults by providing an array with an endpoint as the key and a response as its value as such:

```php
Cashier::fake([
  'subscription/create' => ['fake-response' => 'and its data']
]);
```

Internally, CashierFake will format this path into a paddle API call within the `retrieveEndpoint($path)` call which uses Cashier's `vendorsUrl` method and some constants to return an endpoint such as: `vendors.paddle.com/api/2.0/subscription/create`. From here it will take the faked response and either return it as part of a `Http::response` if it's an array or allow the user to customize that behaviour by passing a function. 

There are two additional methods that can be used: `paypal()` and `card()`. These functions change the information returned by the `subscription/users` endpoint with `paypal()` sending a response that the user is paying via PayPal and `card()` that it is paying through a Visa with the following parameters:

```js
{
  card_type: 'visa',
  last_four_digits: '1234',
  expiry_date: '04/2022',
}
```

If these values need to be overwritten, you may pass your own information to the `card()` method and it will merge this into the response as such:

```php
Cashier::fake()->card(['card_type' => 'mastercard']);
```

Finally the `CashierFake` method also fakes Events provided by the library. These events are:

- Laravel\Paddle\Events\PaymentSucceeded
- Laravel\Paddle\Events\SubscriptionCancelled
- Laravel\Paddle\Events\SubscriptionCreated
- Laravel\Paddle\Events\SubscriptionPaymentFailed
- Laravel\Paddle\Events\SubscriptionPaymentSucceeded
- Laravel\Paddle\Events\SubscriptionUpdated

A user may append additional events to this process if they wish by adding passing them to the fake such as:

```php
Cashier::fake(events: CustomEvent::class);

// or
Cashier::fake(events: [CustomEvent::class, AndAnotherOne::class]);
```

This also provides a number of assertions, present both on the `CashierFake` and `Cashier` class. The assertion methods on the `Cashier` act as a proxy for the `CashierFake` and forward the requests into that class. I went with this approach instead of putting the assertions only on the `Cashier` as I felt importing all the events it needed to cover, plus the Event Facade felt messy and distracts a dev who is trying to understand the concerns of the `Cashier` class. Open to feedback on this one or if someone wants to recommend a better way of doing this.

Example of assertion syntax:
```php
// Switching between Cashier/CashierFake sucks
Cashier::fake()

CashierFake::assertSubscriptionCreated();

// This looks better:
Cashier::fake();

Cashier::assertSubscriptionCreated();

// However this looks like garbage...so again...placed the assertions in CashierFake and 
// did a bit of code duplication in favour of import hell.
use Illuminate\Support\Facades\Http;
use Laravel\Paddle\Exceptions\PaddleException;
use Money\Currencies\ISOCurrencies;
use Money\Currency;
use Money\Formatter\IntlMoneyFormatter;
use Money\Money;
use NumberFormatter;
use Illuminate\Support\Facades\Event;
use Laravel\Paddle\Events\PaymentSucceeded;
use Laravel\Paddle\Events\SubscriptionCancelled;
use Laravel\Paddle\Events\SubscriptionCreated;
use Laravel\Paddle\Events\SubscriptionPaymentFailed;
use Laravel\Paddle\Events\SubscriptionPaymentSucceeded;
use Laravel\Paddle\Events\SubscriptionUpdated;

class Cashier
{
  // ...
}
```

# One final thing...

Let me know if you want me to remove this but I found that setting `<server />` variables in my PHPUnit did nothing...`<env />` did...so I've updated the `CONTRIBUTING.md` file with that. I've also added an env there for `PADDLE_SANDBOX` because it's likely that you're going to be testing in sandbox mode...not sure if this should also be a part of the `phpunit.xml.dist` too...lemme know.