### PR TITLE
Replace heavy `symfony/intl` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "nesbot/carbon": "^2.0",
         "spatie/url": "^1.3.5|^2.0",
         "symfony/http-kernel": "^5.0|^6.0",
-        "symfony/intl": "^5.0|^6.0"
+        "symfony/polyfill-intl-icu": "^1.22.1"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
I've applied the same patch as @GrahamCampbell made for [cashier-stripe](https://github.com/laravel/cashier-stripe/pull/1114).