### PR TITLE
[1.x] Do not allow updating quantities to zero

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -445,7 +445,7 @@ class Subscription extends Model
     {
         $this->guardAgainstUpdates('update quantities');
 
-        if ($quantity == 0) {
+        if ($quantity < 0) {
             throw new LogicException('Paddle does not allow subscriptions to have a quantity of zero.');
         }
 

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -445,6 +445,10 @@ class Subscription extends Model
     {
         $this->guardAgainstUpdates('update quantities');
 
+        if ($quantity == 0) {
+            throw new LogicException('Paddle does not allow subscriptions to have a quantity of zero.');
+        }
+
         $this->updatePaddleSubscription(array_merge($options, [
             'quantity' => $quantity,
             'prorate' => $this->prorate,

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -445,7 +445,7 @@ class Subscription extends Model
     {
         $this->guardAgainstUpdates('update quantities');
 
-        if ($quantity < 0) {
+        if ($quantity < 1) {
             throw new LogicException('Paddle does not allow subscriptions to have a quantity of zero.');
         }
 

--- a/tests/Unit/SubscriptionTest.php
+++ b/tests/Unit/SubscriptionTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use Laravel\Paddle\Subscription;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 
 class SubscriptionTest extends TestCase
@@ -35,5 +36,14 @@ class SubscriptionTest extends TestCase
         $subscription->trial_ends_at = now()->addDay();
 
         $this->assertFalse($subscription->hasExpiredTrial());
+    }
+
+    public function test_it_cannot_update_its_quantity_to_zero()
+    {
+        $subscription = new Subscription();
+
+        $this->expectException(LogicException::class);
+
+        $subscription->updateQuantity(0);
     }
 }


### PR DESCRIPTION
This PR will make quantity methods on a subscription start throwing a `LogicException` when it's attempting to decrease the quantity to zero. This is not possible in Paddle. Right now, if anyone attempts this the code will throw a PaddleException with a message:

> One or more required arguments are missing

This PR will throw an exception faster before hitting the API and provide a more clear message.