### PR TITLE
Modify return type of updateUrl and cancelUrl on Subscription

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -569,7 +569,7 @@ class Subscription extends Model
     /**
      * Get the Paddle update url.
      *
-     * @return array
+     * @return string
      */
     public function updateUrl()
     {
@@ -677,7 +677,7 @@ class Subscription extends Model
     /**
      * Get the Paddle cancellation url.
      *
-     * @return array
+     * @return string
      */
     public function cancelUrl()
     {


### PR DESCRIPTION
I just think this one got missed, or their API has changed since this package was made.

As per their docs, it returns a string (I tested and it seems to be true)

Source: https://developer.paddle.com/api-reference/e33e0a714a05d-list-users#Responses