### PR TITLE
`productPrices()` returns prices in the same order as the input array

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,5 +12,6 @@ Copy the default file using `cp phpunit.xml.dist phpunit.xml` and add the follow
     <env name="PADDLE_VENDOR_ID" value="Your Paddle vendor ID"/>
     <env name="PADDLE_VENDOR_AUTH_CODE" value="Your Paddle auth code"/>
     <env name="PADDLE_TEST_PRODUCT" value="Identifier for a random one off product"/>
+    <env name="PADDLE_TEST_PRODUCT_LOWER_ID" value="Identifier for a random one off product with a lower id than the previous product"/>
 
 After setting these variables, you can run your tests by executing the `vendor/bin/phpunit` command.

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -76,7 +76,9 @@ class Cashier
 
         $response = static::get('/prices', $payload)['response'];
 
-        return collect($response['products'])->map(function (array $product) use ($response) {
+        return collect($response['products'])->keyBy(function (array $product) use ($products) {
+            return array_search($product['product_id'], (array) $products, false);
+        })->map(function (array $product) use ($response) {
             return new ProductPrice($response['customer_country'], $product);
         });
     }

--- a/tests/Feature/PricesTest.php
+++ b/tests/Feature/PricesTest.php
@@ -25,13 +25,28 @@ class PricesTest extends FeatureTestCase
             $this->markTestSkipped('Test products not configured.');
         }
 
-        $prices = Cashier::productPrices([getenv('PADDLE_TEST_PRODUCT'), getenv('PADDLE_TEST_PRODUCT_LOWER_ID')]);
+        $prices = Cashier::productPrices([getenv('PADDLE_TEST_PRODUCT'), getenv('PADDLE_TEST_PRODUCT_LOWER_ID')], preserveOrder: true);
 
         $this->assertNotEmpty($prices);
         $this->assertCount(2, $prices);
         $this->assertContainsOnlyInstancesOf(ProductPrice::class, $prices->all());
         $this->assertEquals($prices[0]->product_id, getenv('PADDLE_TEST_PRODUCT'));
         $this->assertEquals($prices[1]->product_id, getenv('PADDLE_TEST_PRODUCT_LOWER_ID'));
+    }
+
+    public function test_it_can_fetch_the_prices_of_multiple_products_and_does_not_sort_them_by_default()
+    {
+        if (! getenv('PADDLE_TEST_PRODUCT') || ! getenv('PADDLE_TEST_PRODUCT_LOWER_ID')) {
+            $this->markTestSkipped('Test products not configured.');
+        }
+
+        $prices = Cashier::productPrices([getenv('PADDLE_TEST_PRODUCT'), getenv('PADDLE_TEST_PRODUCT_LOWER_ID')]);
+
+        $this->assertNotEmpty($prices);
+        $this->assertCount(2, $prices);
+        $this->assertContainsOnlyInstancesOf(ProductPrice::class, $prices->all());
+        $this->assertEquals($prices[0]->product_id, getenv('PADDLE_TEST_PRODUCT_LOWER_ID'));
+        $this->assertEquals($prices[1]->product_id, getenv('PADDLE_TEST_PRODUCT'));
     }
 
     public function test_it_can_fetch_the_prices_of_products_when_the_input_is_a_string()

--- a/tests/Feature/PricesTest.php
+++ b/tests/Feature/PricesTest.php
@@ -18,4 +18,32 @@ class PricesTest extends FeatureTestCase
         $this->assertNotEmpty($prices);
         $this->assertContainsOnlyInstancesOf(ProductPrice::class, $prices->all());
     }
+
+    public function test_it_can_fetch_the_prices_of_multiple_products_and_sorts_them_based_on_the_input()
+    {
+        if (! getenv('PADDLE_TEST_PRODUCT') || ! getenv('PADDLE_TEST_PRODUCT_LOWER_ID')) {
+            $this->markTestSkipped('Test products not configured.');
+        }
+
+        $prices = Cashier::productPrices([getenv('PADDLE_TEST_PRODUCT'), getenv('PADDLE_TEST_PRODUCT_LOWER_ID')]);
+
+        $this->assertNotEmpty($prices);
+        $this->assertCount(2, $prices);
+        $this->assertContainsOnlyInstancesOf(ProductPrice::class, $prices->all());
+        $this->assertEquals($prices[0]->product_id, getenv('PADDLE_TEST_PRODUCT'));
+        $this->assertEquals($prices[1]->product_id, getenv('PADDLE_TEST_PRODUCT_LOWER_ID'));
+    }
+
+    public function test_it_can_fetch_the_prices_of_products_when_the_input_is_a_string()
+    {
+        if (! getenv('PADDLE_TEST_PRODUCT') || ! getenv('PADDLE_TEST_PRODUCT_LOWER_ID')) {
+            $this->markTestSkipped('Test products not configured.');
+        }
+
+        $prices = Cashier::productPrices(getenv('PADDLE_TEST_PRODUCT'));
+
+        $this->assertNotEmpty($prices);
+        $this->assertContainsOnlyInstancesOf(ProductPrice::class, $prices->all());
+        $this->assertEquals($prices[0]->product_id, getenv('PADDLE_TEST_PRODUCT'));
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
When using the `productPrices()` function to get multiple prices, the response from the API appears to be ordered by the `product_id` ascending, rather than based on the order of the IDs provided in the call.

This means that if you're providing a set of prices, e.g., current price and new price, it is not necessarily true that the first element is the current price. This can lead to some initial confusion.

This pull request uses the input array and an optional flag to then re-key the response to ensure that the orders match the input.

I've updated the tests to include for the check that multiple keys return in the correct order, and I've also added a test to ensure that if a string/int is passed (and not an array) it still works. I've also included a test to ensure that we maintain the backward compatibility.