### PR TITLE
Fix Japanese Yen amounts

### DIFF
--- a/src/Modifier.php
+++ b/src/Modifier.php
@@ -60,6 +60,10 @@ class Modifier
      */
     public function amount()
     {
+        if ($this->currency()->getCode() === 'JPY') {
+            return $this->formatAmount((int) $this->rawAmount());
+        }
+
         return $this->formatAmount((int) ($this->rawAmount() * 100));
     }
 

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -53,6 +53,10 @@ class Payment implements Arrayable, Jsonable, JsonSerializable
      */
     public function amount()
     {
+        if ($this->currency()->getCode() === 'JPY') {
+            return $this->formatAmount((int) $this->rawAmount());
+        }
+
         return $this->formatAmount((int) ($this->rawAmount() * 100));
     }
 

--- a/src/Price.php
+++ b/src/Price.php
@@ -40,6 +40,10 @@ class Price
      */
     public function gross()
     {
+        if ($this->currency()->getCode() === 'JPY') {
+            return $this->formatAmount((int) $this->rawGross());
+        }
+
         return $this->formatAmount((int) ($this->rawGross() * 100));
     }
 
@@ -60,6 +64,10 @@ class Price
      */
     public function net()
     {
+        if ($this->currency()->getCode() === 'JPY') {
+            return $this->formatAmount((int) $this->rawNet());
+        }
+
         return $this->formatAmount((int) ($this->rawNet() * 100));
     }
 
@@ -80,6 +88,10 @@ class Price
      */
     public function tax()
     {
+        if ($this->currency()->getCode() === 'JPY') {
+            return $this->formatAmount((int) $this->rawTax());
+        }
+
         return $this->formatAmount((int) ($this->rawTax() * 100));
     }
 

--- a/src/Receipt.php
+++ b/src/Receipt.php
@@ -51,6 +51,10 @@ class Receipt extends Model
      */
     public function amount()
     {
+        if ($this->currency()->getCode() === 'JPY') {
+            return $this->formatAmount((int) $this->amount);
+        }
+
         return $this->formatAmount((int) ($this->amount * 100));
     }
 
@@ -61,6 +65,10 @@ class Receipt extends Model
      */
     public function tax()
     {
+        if ($this->currency()->getCode() === 'JPY') {
+            return $this->formatAmount((int) $this->tax);
+        }
+
         return $this->formatAmount((int) ($this->tax * 100));
     }
 

--- a/tests/Feature/PaymentTest.php
+++ b/tests/Feature/PaymentTest.php
@@ -17,6 +17,15 @@ class PaymentTest extends FeatureTestCase
         $this->assertSame('EUR', $payment->currency()->getCode());
     }
 
+    public function test_it_can_returns_a_japanese_amount_and_currency()
+    {
+        $payment = new Payment('1200.0', 'JPY', '2020-05-07');
+
+        $this->assertSame('¥1,200', $payment->amount());
+        $this->assertSame('1200.0', $payment->rawAmount());
+        $this->assertSame('JPY', $payment->currency()->getCode());
+    }
+
     public function test_it_can_be_serialized_to_an_array()
     {
         $payment = new Payment('12.45', 'EUR', '2020-05-07');

--- a/tests/Unit/CashierTest.php
+++ b/tests/Unit/CashierTest.php
@@ -17,4 +17,10 @@ class CashierTest extends TestCase
         $this->assertSame('$10', Cashier::formatAmount(1000, null, null, ['min_fraction_digits' => 0]));
         $this->assertSame('$10.1', Cashier::formatAmount(1010, null, null, ['min_fraction_digits' => 0]));
     }
+
+    public function test_it_can_format_jpy_amounts()
+    {
+        $this->assertSame('¥1,000', Cashier::formatAmount(1000, 'JPY'));
+        $this->assertSame('¥1,010', Cashier::formatAmount(1010, 'JPY'));
+    }
 }


### PR DESCRIPTION
This fixes an issue where Japanese Yen amounts weren't displayed properly. Since Japanese Yen doesn't have cent amounts, they don't need the `* 100` modifier before being parsed into a money format. This PR checks if the currency is Japanese Yen and fixes the displayed value to the proper amount.

Fixes https://github.com/laravel/cashier-paddle/issues/183