### PR TITLE
Handle the paddle decimal amount

### DIFF
--- a/src/Concerns/ManagesAmounts.php
+++ b/src/Concerns/ManagesAmounts.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Laravel\Paddle\Concerns;
+
+use Laravel\Paddle\Cashier;
+
+trait ManagesAmounts
+{
+    /**
+     * Format the given amount into a displayable currency.
+     *
+     * @param  int  $amount
+     * @return string
+     */
+    protected function formatAmount($amount)
+    {
+        return Cashier::formatAmount($amount, $this->currency());
+    }
+
+    /**
+     * Format the Paddle decimal into a displayable currency.
+     *
+     * @param  $amount
+     * @return string
+     */
+    protected function formatDecimalAmount($amount)
+    {
+        if (! Cashier::currencyUsesCents($this->currency())) {
+            return $this->formatAmount((int) $amount);
+        }
+
+        return $this->formatAmount((int) ($amount * 100));
+    }
+}

--- a/src/Concerns/ManagesAmounts.php
+++ b/src/Concerns/ManagesAmounts.php
@@ -20,7 +20,7 @@ trait ManagesAmounts
     /**
      * Format the Paddle decimal into a displayable currency.
      *
-     * @param  $amount
+     * @param  string  $amount
      * @return string
      */
     protected function formatDecimalAmount($amount)

--- a/src/Concerns/ManagesAmounts.php
+++ b/src/Concerns/ManagesAmounts.php
@@ -20,7 +20,7 @@ trait ManagesAmounts
     /**
      * Format the Paddle decimal into a displayable currency.
      *
-     * @param  string  $amount
+     * @param  float  $amount
      * @return string
      */
     protected function formatDecimalAmount($amount)

--- a/src/Modifier.php
+++ b/src/Modifier.php
@@ -2,10 +2,13 @@
 
 namespace Laravel\Paddle;
 
+use Laravel\Paddle\Concerns\ManagesAmounts;
 use Money\Currency;
 
 class Modifier
 {
+    use ManagesAmounts;
+
     /**
      * The Subscription model the modifier belongs to.
      *
@@ -60,11 +63,7 @@ class Modifier
      */
     public function amount()
     {
-        if (! Cashier::currencyUsesCents($this->currency())) {
-            return $this->formatAmount((int) $this->rawAmount());
-        }
-
-        return $this->formatAmount((int) ($this->rawAmount() * 100));
+        return $this->formatDecimalAmount($this->rawAmount());
     }
 
     /**
@@ -85,17 +84,6 @@ class Modifier
     public function currency(): Currency
     {
         return new Currency($this->modifier['currency']);
-    }
-
-    /**
-     * Format the given amount into a displayable currency.
-     *
-     * @param  int  $amount
-     * @return string
-     */
-    protected function formatAmount($amount)
-    {
-        return Cashier::formatAmount($amount, $this->currency());
     }
 
     /**

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -6,10 +6,13 @@ use Carbon\Carbon;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use JsonSerializable;
+use Laravel\Paddle\Concerns\ManagesAmounts;
 use Money\Currency;
 
 class Payment implements Arrayable, Jsonable, JsonSerializable
 {
+    use ManagesAmounts;
+
     /**
      * The amount of the payment.
      *
@@ -53,11 +56,7 @@ class Payment implements Arrayable, Jsonable, JsonSerializable
      */
     public function amount()
     {
-        if (! Cashier::currencyUsesCents($this->currency())) {
-            return $this->formatAmount((int) $this->rawAmount());
-        }
-
-        return $this->formatAmount((int) ($this->rawAmount() * 100));
+        return $this->formatDecimalAmount($this->rawAmount());
     }
 
     /**
@@ -78,17 +77,6 @@ class Payment implements Arrayable, Jsonable, JsonSerializable
     public function currency(): Currency
     {
         return new Currency($this->currency);
-    }
-
-    /**
-     * Format the given amount into a displayable currency.
-     *
-     * @param  int  $amount
-     * @return string
-     */
-    protected function formatAmount($amount)
-    {
-        return Cashier::formatAmount($amount, $this->currency);
     }
 
     /**

--- a/src/Price.php
+++ b/src/Price.php
@@ -2,10 +2,13 @@
 
 namespace Laravel\Paddle;
 
+use Laravel\Paddle\Concerns\ManagesAmounts;
 use Money\Currency;
 
 class Price
 {
+    use ManagesAmounts;
+
     /**
      * The price attributes.
      *
@@ -40,11 +43,7 @@ class Price
      */
     public function gross()
     {
-        if (! Cashier::currencyUsesCents($this->currency())) {
-            return $this->formatAmount((int) $this->rawGross());
-        }
-
-        return $this->formatAmount((int) ($this->rawGross() * 100));
+        return $this->formatDecimalAmount($this->rawGross());
     }
 
     /**
@@ -64,11 +63,7 @@ class Price
      */
     public function net()
     {
-        if (! Cashier::currencyUsesCents($this->currency())) {
-            return $this->formatAmount((int) $this->rawNet());
-        }
-
-        return $this->formatAmount((int) ($this->rawNet() * 100));
+        return $this->formatDecimalAmount($this->rawNet());
     }
 
     /**
@@ -88,11 +83,7 @@ class Price
      */
     public function tax()
     {
-        if (! Cashier::currencyUsesCents($this->currency())) {
-            return $this->formatAmount((int) $this->rawTax());
-        }
-
-        return $this->formatAmount((int) ($this->rawTax() * 100));
+        return $this->formatDecimalAmount($this->rawTax());
     }
 
     /**
@@ -123,17 +114,6 @@ class Price
     public function currency(): Currency
     {
         return $this->currency;
-    }
-
-    /**
-     * Format the given amount into a displayable currency.
-     *
-     * @param  int  $amount
-     * @return string
-     */
-    protected function formatAmount($amount)
-    {
-        return Cashier::formatAmount($amount, $this->currency);
     }
 
     /**

--- a/src/Receipt.php
+++ b/src/Receipt.php
@@ -3,10 +3,13 @@
 namespace Laravel\Paddle;
 
 use Illuminate\Database\Eloquent\Model;
+use Laravel\Paddle\Concerns\ManagesAmounts;
 use Money\Currency;
 
 class Receipt extends Model
 {
+    use ManagesAmounts;
+
     /**
      * The attributes that are not mass assignable.
      *
@@ -51,11 +54,7 @@ class Receipt extends Model
      */
     public function amount()
     {
-        if (! Cashier::currencyUsesCents($this->currency())) {
-            return $this->formatAmount((int) $this->amount);
-        }
-
-        return $this->formatAmount((int) ($this->amount * 100));
+        return $this->formatDecimalAmount($this->amount);
     }
 
     /**
@@ -65,11 +64,7 @@ class Receipt extends Model
      */
     public function tax()
     {
-        if (! Cashier::currencyUsesCents($this->currency())) {
-            return $this->formatAmount((int) $this->tax);
-        }
-
-        return $this->formatAmount((int) ($this->tax * 100));
+        return $this->formatDecimalAmount($this->tax);
     }
 
     /**
@@ -80,16 +75,5 @@ class Receipt extends Model
     public function currency(): Currency
     {
         return new Currency($this->currency);
-    }
-
-    /**
-     * Format the given amount into a displayable currency.
-     *
-     * @param  int  $amount
-     * @return string
-     */
-    protected function formatAmount($amount)
-    {
-        return Cashier::formatAmount($amount, $this->currency);
     }
 }


### PR DESCRIPTION
* introduce formatDecimalAmount to handle the format that paddle returns from api calls.
* move the amount logic into a new trait

This maintains backward compatibility as `formatAmount()` is unchanged.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
