### PR TITLE
Update subscription paused() method

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -175,7 +175,7 @@ class Subscription extends Model
      */
     public function paused()
     {
-        return $this->paddle_status === self::STATUS_PAUSED;
+        return $this->paddle_status === self::STATUS_PAUSED || $this->onPausedGracePeriod();
     }
 
     /**


### PR DESCRIPTION
fix issue #189 

Because of paddle pause subscription API return status as active, so when determine paused subscription status by paused() method, return false. 
now for fix it we must check paused_from column for determine that.