### PR TITLE
Resolve some subscription property via @property

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -10,6 +10,12 @@ use Laravel\Paddle\Concerns\Prorates;
 use LogicException;
 
 /**
+ * @property int $id
+ * @property int $billable_id
+ * @property string $name
+ * @property Carbon $ends_at
+ * @property int $paddle_plan
+ * @property Carbon $trial_ends_at
  * @property \Laravel\Paddle\Billable $billable
  */
 class Subscription extends Model


### PR DESCRIPTION
This solves annoying warning from IDE when accessing to `subscription` model property

![image](https://github.com/laravel/cashier-paddle/assets/77144/d04eb362-ed39-46a5-96fb-39d34ad48746)

