### PR TITLE
Handle duplicated subscription created event

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -157,6 +157,10 @@ class WebhookController extends Controller
             throw new InvalidPassthroughPayload;
         }
 
+        if ($this->subscriptionExists($payload['subscription_id'])) {
+            return;
+        }
+
         $customer = $this->findOrCreateCustomer($payload['passthrough']);
 
         $trialEndsAt = $payload['status'] === Subscription::STATUS_TRIALING
@@ -276,6 +280,17 @@ class WebhookController extends Controller
     protected function findSubscription(string $subscriptionId)
     {
         return Cashier::$subscriptionModel::firstWhere('paddle_id', $subscriptionId);
+    }
+
+    /**
+     * Determine if a subscription with a given Paddle ID already exists.
+     *
+     * @param  string  $subscriptionId
+     * @return bool
+     */
+    protected function subscriptionExists(string $subscriptionId)
+    {
+        return Cashier::$subscriptionModel::where('paddle_id', $subscriptionId)->exists();
     }
 
     /**


### PR DESCRIPTION
 If for any reason `subscription_created` webhook is called more than once and the subscription was created on the first one, the subsequent calls will return a 500 status error as a result of the unique constraint on paddle_id.
 
 This PR solves this issue by checking if the subscription exists before proceeding. 