### PR TITLE
[1.x] Fix Livewire support

### DIFF
--- a/resources/views/js.blade.php
+++ b/resources/views/js.blade.php
@@ -1,11 +1,13 @@
 @php($vendor = ['vendor' => (int) config('cashier.vendor_id')])
 
 <script src="https://cdn.paddle.com/paddle/paddle.js"></script>
+
 @if (config('cashier.sandbox'))
     <script type="text/javascript">
         Paddle.Environment.set('sandbox');
     </script>
 @endif
+
 <script type="text/javascript">
     Paddle.Setup(@json($vendor));
 </script>

--- a/resources/views/js.blade.php
+++ b/resources/views/js.blade.php
@@ -1,10 +1,11 @@
 @php($vendor = ['vendor' => (int) config('cashier.vendor_id')])
 
 <script src="https://cdn.paddle.com/paddle/paddle.js"></script>
-<script type="text/javascript">
-    @if (config('cashier.sandbox'))
+@if (config('cashier.sandbox'))
+    <script type="text/javascript">
         Paddle.Environment.set('sandbox');
-    @endif
-
+    </script>
+@endif
+<script type="text/javascript">
     Paddle.Setup(@json($vendor));
 </script>


### PR DESCRIPTION
I noticed that I was getting 404s by Paddle on a staging environment. The 404s were on the product domain and caused by the fact that certain plan IDs could not be found.

I double checked the HTML to see if the environment was set correctly. Apparently the code for setting the environment to Sandbox environment was present. However, when running `Paddle.Environment.get()` in the console, it would return `production` as environment. 

I was able to pinpoint the issue to Livewire and the fact that Livewire v3 now introduces `__BLOCK__` comments in HTML around Blade `@if`'s:

<img width="796" alt="Script" src="https://github.com/laravel/cashier-paddle/assets/59207045/a17e90ac-6aae-4863-9c26-ca0a72ebf75a">

Since the if-condition was inside a `<script>` tag, JavaScript doesn't know how to handle this comment well, and therefore the environment would never be set to sandbox. This PR solves the Livewire compatibility by putting the Environment set call in a separate script tag.

Thanks!
