### PR TITLE
Added the missing paddle_subscription_id column in migration

### DIFF
--- a/database/migrations/2019_05_03_000003_create_subscription_items_table.php
+++ b/database/migrations/2019_05_03_000003_create_subscription_items_table.php
@@ -16,6 +16,7 @@ return new class extends Migration
             $table->foreignId('subscription_id');
             $table->string('product_id');
             $table->string('price_id');
+            $table->string('paddle_subscription_id');
             $table->string('status');
             $table->integer('quantity');
             $table->timestamps();


### PR DESCRIPTION
The migration was simply missing the field and "subscription.created" events made the webhook handler complain about it.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
