### PR TITLE
[2.x] Cashier Paddle v2: Minor updates

### DIFF
--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -290,6 +290,17 @@ class Cashier
     }
 
     /**
+     * Set the subscription item model class name.
+     *
+     * @param  string  $subscriptionItemModel
+     * @return void
+     */
+    public static function useSubscriptionItemModel($subscriptionItemModel)
+    {
+        static::$subscriptionItemModel = $subscriptionItemModel;
+    }
+
+    /**
      * Set the transaction model class name.
      *
      * @param  string  $transactionModel

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Laravel\Paddle;
+
+use Carbon\Carbon;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use JsonSerializable;
+use Money\Currency;
+
+class Payment implements Arrayable, Jsonable, JsonSerializable
+{
+    /**
+     * The amount of the payment.
+     *
+     * @var string
+     */
+    public $amount;
+
+    /**
+     * The currency of the payment.
+     *
+     * @var string
+     */
+    public $currency;
+
+    /**
+     * The payment date.
+     *
+     * @var \Carbon\Carbon
+     */
+    public $date;
+
+    /**
+     * Create a new Payment instance.
+     *
+     * @param  string  $amount
+     * @param  string  $currency
+     * @param  \Carbon\Carbon  $date
+     * @return void
+     */
+    public function __construct($amount, $currency, $date)
+    {
+        $this->amount = $amount;
+        $this->currency = $currency;
+        $this->date = $date;
+    }
+
+    /**
+     * Get the total amount of the payment.
+     *
+     * @return string
+     */
+    public function amount()
+    {
+        return Cashier::formatAmount($this->amount, $this->currency);
+    }
+
+    /**
+     * Get the raw total of the payment.
+     *
+     * @return string
+     */
+    public function rawAmount()
+    {
+        return $this->amount;
+    }
+
+    /**
+     * Get the used currency for the payment.
+     *
+     * @return \Money\Currency
+     */
+    public function currency(): Currency
+    {
+        return new Currency($this->currency);
+    }
+
+    /**
+     * Get the date of the payment as a Carbon instance.
+     *
+     * @return \Carbon\Carbon
+     */
+    public function date()
+    {
+        return $this->date;
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'amount' => $this->amount(),
+            'currency' => $this->currency,
+            'date' => $this->date()->toIso8601String(),
+        ];
+    }
+
+    /**
+     * Convert the object to its JSON representation.
+     *
+     * @param  int  $options
+     * @return string
+     */
+    public function toJson($options = 0)
+    {
+        return json_encode($this->jsonSerialize(), $options);
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -67,7 +67,7 @@ class Payment implements Arrayable, Jsonable, JsonSerializable
     }
 
     /**
-     * Get the used currency for the payment.
+     * Get the currency used for the payment.
      *
      * @return \Money\Currency
      */

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -682,7 +682,7 @@ class Subscription extends Model
     }
 
     /**
-     * Get the raw Transaction used to update the payment method on file.
+     * Get the raw transaction used to update the payment method on file.
      *
      * @return array
      */


### PR DESCRIPTION
- Adds a missing `useSubscriptionItemModel` method
- Adds a new `paymentMethodUpdateTransaction` method
- Removes the `nextBilledAt` method and re-adds the `lastPayment` and `nextPayment` methods