### PR TITLE
[develop] Adds Laravel 11 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,10 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.1, 8.2, 8.3]
-        laravel: [10]
+        laravel: [10, 11]
+        exclude:
+          - php: 8.1
+            laravel: 11
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -22,23 +22,23 @@
         "ext-json": "*",
         "ext-openssl": "*",
         "guzzlehttp/guzzle": "^7.4.5",
-        "illuminate/contracts": "^10.0",
-        "illuminate/database": "^10.0",
-        "illuminate/http": "^10.0",
-        "illuminate/routing": "^10.0",
-        "illuminate/support": "^10.0",
-        "illuminate/view": "^10.0",
+        "illuminate/contracts": "^10.0|^11.0",
+        "illuminate/database": "^10.0|^11.0",
+        "illuminate/http": "^10.0|^11.0",
+        "illuminate/routing": "^10.0|^11.0",
+        "illuminate/support": "^10.0|^11.0",
+        "illuminate/view": "^10.0|^11.0",
         "moneyphp/money": "^3.2|^4.0",
         "nesbot/carbon": "^2.67",
         "spatie/url": "^1.3.5|^2.0",
-        "symfony/http-kernel": "^6.2",
+        "symfony/http-kernel": "^6.2|^7.0",
         "symfony/polyfill-intl-icu": "^1.22.1"
     },
     "require-dev": {
         "mockery/mockery": "^1.5.1",
-        "orchestra/testbench": "^8.14",
+        "orchestra/testbench": "^8.14|^9.0",
         "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^10.1"
+        "phpunit/phpunit": "^10.4"
     },
     "suggest": {
         "ext-intl": "Allows for more locales besides the default \"en\" when formatting money values."


### PR DESCRIPTION
This pull request adds Laravel 11 support to Chashier Paddle.

I've reverted https://github.com/laravel/cashier-paddle/pull/211 on master because this PR was meant to target `develop`.