### PR TITLE
[2.x] Update Cashier::api error message

### DIFF
--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -128,7 +128,13 @@ class Cashier
             ->$method("{$host}/{$uri}", $payload);
 
         if (isset($response['error'])) {
-            throw new PaddleException(json_encode($response['error']));
+            $message = "Paddle API error '{$response['error']['detail']}' occurred";
+
+            if (isset($response['error']['errors'])) {
+                $message .= ' with validation errors ('.json_encode($response['error']['errors']).')';
+            }
+
+            throw new PaddleException($response['error']['detail']);
         }
 
         return $response;

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -128,7 +128,7 @@ class Cashier
             ->$method("{$host}/{$uri}", $payload);
 
         if (isset($response['error'])) {
-            throw new PaddleException($response['error']['detail']);
+            throw new PaddleException(json_encode($response['error']));
         }
 
         return $response;

--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -3,6 +3,7 @@
 namespace Laravel\Paddle\Concerns;
 
 use Laravel\Paddle\Cashier;
+use LogicException;
 
 trait ManagesCustomer
 {
@@ -23,6 +24,10 @@ trait ManagesCustomer
 
         if (! array_key_exists('email', $options) && $email = $this->paddleEmail()) {
             $options['email'] = $email;
+        }
+
+        if (! isset($options['email'])) {
+            throw new LogicException('Unable to create Paddle customer without an email.');
         }
 
         $trialEndsAt = $options['trial_ends_at'] ?? null;


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hello, I just spent two days debugging an error that can be easily debugged, if the error message is descriptive. But Paddle seems just to say "Invalid Request" or this is what I thought. My problem was not a bug it was a "bad request" because I did not pass something important (email) that my Billable class didn't have (Team). Nevertheless, the way I debugged this, is by digging to the source of the error (Cashier::api) and dd its response which is the following:
![2023_12_08_02_09_37_Window](https://github.com/laravel/cashier-paddle/assets/81206551/302ee8d6-9478-4762-b8d6-5ab529483d0a)

Clearly, the error by Paddle is descriptive but its (detail) not very much. I don't want anyone to waste his time debugging an error that does not exist on the error stack.
Before my pull request:
![2023-12-08 02_21_20-Business - Laptop POS and 2 more pages - Personal - Microsoft​ Edge](https://github.com/laravel/cashier-paddle/assets/81206551/309f32ef-6d06-45e1-9413-4292a5cbcc40)

After:
![2023-12-08 02_20_21-Business - Laptop POS and 2 more pages - Personal - Microsoft​ Edge](https://github.com/laravel/cashier-paddle/assets/81206551/fa820a4f-fe3b-46a5-a962-5b144bd6393b)
Thank you very much for your patience, keep up the great work!