### PR TITLE
[2.x] Clear generic trial for subscription creation

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -174,6 +174,8 @@ class WebhookController extends Controller
             ]);
         }
 
+        $billable->customer->update(['trial_ends_at' => null]);
+
         SubscriptionCreated::dispatch($billable, $subscription, $payload);
     }
 


### PR DESCRIPTION
This is currently already done in Spark but should just be part of Cashier as well I believe. 

Fixes https://github.com/laravel/cashier-paddle/issues/221