### PR TITLE
Fix updateQuantity issue - Remove pluck()

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -532,7 +532,7 @@ class Subscription extends Model
 
         $itemToUpdate = $price instanceof SubscriptionItem ? $price : $this->singleItemOrFail($price);
 
-        $items = $this->items()->get(['quantity', 'price_id'])->pluck(['quantity', 'price_id'])->toArray();
+        $items = $this->items()->get(['quantity', 'price_id'])->toArray();
 
         foreach ($items as $key => $item) {
             if ($item['price_id'] === $itemToUpdate->price_id) {


### PR DESCRIPTION
### Issue

The `updateQuantity()` method was failing and throwing the error below.

![image](https://github.com/laravel/cashier-paddle/assets/42672551/2c3d7026-7fec-499b-ac7d-c45a4a6f98f9)

Running `pluck(['quantity', 'price_id'])` on the result from `get(['quantity', 'price_id'])` was returning null in the following line
`$items = $this->items()->get(['quantity', 'price_id'])->pluck(['quantity', 'price_id'])->toArray();`

I'm also not sure you could pass and array to `pluck`, I think this was added by mistake.

### Solution

Removed `pluck(['quantity', 'price_id'])`