### PR TITLE
[2.x] Use proper API Key naming

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Copy the default file using `cp phpunit.xml.dist phpunit.xml` and add the follow
 
     <env name="PADDLE_SANDBOX" value="true"/>
     <env name="PADDLE_SELLER_ID" value="Your Paddle seller ID"/>
-    <env name="PADDLE_AUTH_CODE" value="Your Paddle auth code"/>
+    <env name="PADDLE_API_KEY" value="Your Paddle api key"/>
     <env name="PADDLE_TEST_PRICE" value="Identifier for a random one off price"/>
 
 After setting these variables, you can run your tests by executing the `vendor/bin/phpunit` command.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,6 @@ jobs:
         run: vendor/bin/phpunit
         env:
           PADDLE_SELLER_ID: ${{ secrets.PADDLE_SELLER_ID }}
-          PADDLE_AUTH_CODE: ${{ secrets.PADDLE_AUTH_CODE }}
+          PADDLE_API_KEY: ${{ secrets.PADDLE_API_KEY }}
           PADDLE_WEBHOOK_SECRET: ${{ secrets.PADDLE_WEBHOOK_SECRET }}
           PADDLE_TEST_PRICE: ${{ secrets.PADDLE_TEST_PRICE }}

--- a/config/cashier.php
+++ b/config/cashier.php
@@ -7,15 +7,15 @@ return [
     | Paddle Keys
     |--------------------------------------------------------------------------
     |
-    | The Paddle seller ID and auth code will allow your application to call
-    | the Paddle API. The "public" key is typically used when interacting
-    | with Paddle.js while the "secret" key accesses private endpoints.
+    | The Paddle seller ID and API key will allow your application to call
+    | the Paddle API. The "seller" key is typically used when interacting
+    | with Paddle.js while the "API" key accesses private endpoints.
     |
     */
 
     'seller_id' => env('PADDLE_SELLER_ID'),
 
-    'auth_code' => env('PADDLE_AUTH_CODE'),
+    'api_key' => env('PADDLE_AUTH_CODE') ?? env('PADDLE_API_KEY'),
 
     'retain_key' => env('PADDLE_RETAIN_KEY'),
 

--- a/config/cashier.php
+++ b/config/cashier.php
@@ -8,8 +8,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | The Paddle seller ID and API key will allow your application to call
-    | the Paddle API. The "seller" key is typically used when interacting
-    | with Paddle.js while the "API" key accesses private endpoints.
+    | the Paddle API. The seller key is typically used when interacting
+    | with Paddle.js, while the "API" key accesses private endpoints.
     |
     */
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,7 +18,7 @@
     </testsuites>
     <php>
         <env name="DB_CONNECTION" value="testing"/>
-        <env name="PADDLE_AUTH_CODE" value="fake"/>
+        <env name="PADDLE_API_KEY" value="fake"/>
         <env name="PADDLE_SANDBOX" value="true"/>
     </php>
 </phpunit>

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -115,7 +115,7 @@ class Cashier
      */
     public static function api($method, $uri, array $payload = [])
     {
-        if (empty($apiKey = config('cashier.auth_code'))) {
+        if (empty($apiKey = config('cashier.api_key', config('cashier.auth_code')))) {
             throw new Exception('Paddle API key not set.');
         }
 


### PR DESCRIPTION
Paddle used to name these "auth codes" but has recently changed the terminology to "api keys" so I thought it'd be good to take this into the library itself. This PR is completely backwards compatible and I'll also PR the docs and Spark after this.