### PR TITLE
Add support for Client Side Tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ composer.lock
 /phpunit.xml
 /.phpunit.cache
 .phpunit.result.cache
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 /phpunit.xml
 /.phpunit.cache
 .phpunit.result.cache
+.idea

--- a/config/cashier.php
+++ b/config/cashier.php
@@ -15,6 +15,8 @@ return [
 
     'seller_id' => env('PADDLE_SELLER_ID'),
 
+    'client_side_token' => env('PADDLE_CLIENT_SIDE_TOKEN'),
+
     'api_key' => env('PADDLE_AUTH_CODE') ?? env('PADDLE_API_KEY'),
 
     'retain_key' => env('PADDLE_RETAIN_KEY'),

--- a/resources/views/js.blade.php
+++ b/resources/views/js.blade.php
@@ -1,8 +1,13 @@
 <?php
 $seller = array_filter([
-    'seller' => (int) config('cashier.seller_id'),
-    'pwAuth' => (int) config('cashier.retain_key'),
+    'pwAuth' => (int)config('cashier.retain_key'),
 ]);
+
+if (config('cashier.client_side_token')) {
+    $seller['token'] = config('cashier.client_side_token');
+} elseif (config('cashier.seller_id')) {
+    $seller['seller'] = (int)config('cashier.seller_id');
+}
 
 if (isset($seller['pwAuth']) && Auth::check() && $customer = Auth::user()->customer) {
     $seller['pwCustomer'] = ['id' => $customer->paddle_id];

--- a/resources/views/js.blade.php
+++ b/resources/views/js.blade.php
@@ -1,12 +1,13 @@
 <?php
+
 $seller = array_filter([
-    'pwAuth' => (int)config('cashier.retain_key'),
+    'pwAuth' => (int) config('cashier.retain_key'),
 ]);
 
 if (config('cashier.client_side_token')) {
     $seller['token'] = config('cashier.client_side_token');
 } elseif (config('cashier.seller_id')) {
-    $seller['seller'] = (int)config('cashier.seller_id');
+    $seller['seller'] = (int) config('cashier.seller_id');
 }
 
 if (isset($seller['pwAuth']) && Auth::check() && $customer = Auth::user()->customer) {


### PR DESCRIPTION
I see you previously closed a [request](https://github.com/laravel/cashier-paddle/issues/244) related to this, as it was out of scope (However I'm assuming you were referring to the pricing preview feature itself).

Seeing as Paddle has mostly replaced all their documentation to refer to the "client side token" instead of the seller id, I think its wise to add support for- and prefer this method of configuration, as Paddle has stated that this is the preferred way now.

### Quote from the changelog.

> Existing methods that use seller will continue to work, but future methods may require client-side tokens. **We recommend that you replace the seller parameter with token** and a client-side token when you're next reviewing your code.

https://developer.paddle.com/changelog/2023/client-side-tokens


### Implementation Details

This PR adds the `client_side_token` configuration key, and uses the `PADDLE_CLIENT_SIDE_TOKEN` env key.

If no client side token is provided, it use the `seller_id` as before, however the `client_side token` will be take precedence over the `seller_id` if provided.

### Breaking changes

**None**.

This change will not have any effect for existing consumers of the package unless they add the new env or config option to their code.