### PR TITLE
[2.x] Add the ability to get the paddle error

### DIFF
--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -134,7 +134,7 @@ class Cashier
                 $message .= ' with validation errors ('.json_encode($response['error']['errors']).')';
             }
 
-            throw new PaddleException($response['error']['detail']);
+            throw (new PaddleException($message))->setError($response['error']);
         }
 
         return $response;

--- a/src/Exceptions/PaddleException.php
+++ b/src/Exceptions/PaddleException.php
@@ -6,5 +6,33 @@ use Exception;
 
 class PaddleException extends Exception
 {
-    //
+    /**
+     * The error response from Paddle.
+     *
+     * @var array
+     */
+    protected array $error = [];
+
+    /**
+     * Set the error response from Paddle.
+     *
+     * @param  array  $error
+     * @return self
+     */
+    public function setError(array $error): self
+    {
+        $this->error = $error;
+
+        return $this;
+    }
+
+    /**
+     * Get the error response from Paddle.
+     *
+     * @return array
+     */
+    public function getError(): array
+    {
+        return $this->error;
+    }
 }

--- a/src/Exceptions/PaddleException.php
+++ b/src/Exceptions/PaddleException.php
@@ -14,6 +14,16 @@ class PaddleException extends Exception
     protected array $error = [];
 
     /**
+     * Get the error response from Paddle.
+     *
+     * @return array
+     */
+    public function getError(): array
+    {
+        return $this->error;
+    }
+
+    /**
      * Set the error response from Paddle.
      *
      * @param  array  $error
@@ -24,15 +34,5 @@ class PaddleException extends Exception
         $this->error = $error;
 
         return $this;
-    }
-
-    /**
-     * Get the error response from Paddle.
-     *
-     * @return array
-     */
-    public function getError(): array
-    {
-        return $this->error;
     }
 }


### PR DESCRIPTION
The aim of this pull request to make it easier to get the paddle error response. The `Cashier` currently throws an exception when Paddle returns an error, but it only provides the `error.detail`.

There is also a `$message` variable which is set but never used. I've therefore updated the `PaddleException` to use that custom `$message` variable and added a method for getting the Paddle error response.

One of the main use cases behind this PR, is being able to get the validation messages and formatting them into a readable format for the user.