### PR TITLE
[2.x] Use morphs method in migrations

### DIFF
--- a/database/migrations/2019_05_03_000001_create_customers_table.php
+++ b/database/migrations/2019_05_03_000001_create_customers_table.php
@@ -19,8 +19,6 @@ return new class extends Migration
             $table->string('email');
             $table->timestamp('trial_ends_at')->nullable();
             $table->timestamps();
-
-            $table->index(['billable_id', 'billable_type']);
         });
     }
 

--- a/database/migrations/2019_05_03_000001_create_customers_table.php
+++ b/database/migrations/2019_05_03_000001_create_customers_table.php
@@ -13,8 +13,7 @@ return new class extends Migration
     {
         Schema::create('customers', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('billable_id');
-            $table->string('billable_type');
+            $table->morphs('billable');
             $table->string('paddle_id')->unique();
             $table->string('name');
             $table->string('email');

--- a/database/migrations/2019_05_03_000002_create_subscriptions_table.php
+++ b/database/migrations/2019_05_03_000002_create_subscriptions_table.php
@@ -21,8 +21,6 @@ return new class extends Migration
             $table->timestamp('paused_at')->nullable();
             $table->timestamp('ends_at')->nullable();
             $table->timestamps();
-
-            $table->index(['billable_id', 'billable_type']);
         });
     }
 

--- a/database/migrations/2019_05_03_000002_create_subscriptions_table.php
+++ b/database/migrations/2019_05_03_000002_create_subscriptions_table.php
@@ -13,8 +13,7 @@ return new class extends Migration
     {
         Schema::create('subscriptions', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('billable_id');
-            $table->string('billable_type');
+            $table->morps('billable');
             $table->string('type');
             $table->string('paddle_id')->unique();
             $table->string('status');

--- a/database/migrations/2019_05_03_000002_create_subscriptions_table.php
+++ b/database/migrations/2019_05_03_000002_create_subscriptions_table.php
@@ -13,8 +13,7 @@ return new class extends Migration
     {
         Schema::create('subscriptions', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('billable_id');
-            $table->string('billable_type');
+            $table->morphs('billable');
             $table->string('type');
             $table->string('paddle_id')->unique();
             $table->string('status');

--- a/database/migrations/2019_05_03_000004_create_transactions_table.php
+++ b/database/migrations/2019_05_03_000004_create_transactions_table.php
@@ -13,8 +13,7 @@ return new class extends Migration
     {
         Schema::create('transactions', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('billable_id');
-            $table->string('billable_type');
+            $table->morphs('billable');
             $table->string('paddle_id')->unique();
             $table->string('paddle_subscription_id')->nullable()->index();
             $table->string('invoice_number')->nullable();

--- a/database/migrations/2019_05_03_000004_create_transactions_table.php
+++ b/database/migrations/2019_05_03_000004_create_transactions_table.php
@@ -23,8 +23,6 @@ return new class extends Migration
             $table->string('currency', 3);
             $table->timestamp('billed_at');
             $table->timestamps();
-
-            $table->index(['billable_id', 'billable_type']);
         });
     }
 


### PR DESCRIPTION
This PR improves the code by using the `morphs` method for polymorphic relationships, replacing the need for `billable_id` and `billable_type` columns and the `index` method. This leads to cleaner, more efficient code with improved maintainability and readability.