### PR TITLE
Fix typo in stop cancellation method.

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -858,7 +858,7 @@ class Subscription extends Model
     /**
      * Stop the subscription from being canceled at the end of the current billing period.
      *
-     * @deprecated function contain typo in name and will be removed in a future version. Use stopCancellation instead.
+     * @deprecated Use stopCancellation instead.
      * @return $this
      */
     public function stopCancelation()

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -859,6 +859,7 @@ class Subscription extends Model
      * Stop the subscription from being canceled at the end of the current billing period.
      *
      * @deprecated Use stopCancellation instead.
+     * 
      * @return $this
      */
     public function stopCancelation()

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -859,7 +859,7 @@ class Subscription extends Model
      * Stop the subscription from being canceled at the end of the current billing period.
      *
      * @deprecated Use stopCancellation instead.
-     * 
+     *
      * @return $this
      */
     public function stopCancelation()

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -858,9 +858,20 @@ class Subscription extends Model
     /**
      * Stop the subscription from being canceled at the end of the current billing period.
      *
+     * @deprecated function contain typo in name and will be removed in a future version. Use stopCancellation instead.
      * @return $this
      */
     public function stopCancelation()
+    {
+        return $this->stopCancellation();
+    }
+
+    /**
+     * Stop the subscription from being canceled at the end of the current billing period.
+     *
+     * @return $this
+     */
+    public function stopCancellation()
     {
         $response = $this->updatePaddleSubscription(['scheduled_change' => null]);
 


### PR DESCRIPTION
Function `stopCancelation` is using avoided spelling for cancellation. Renaming it to use accepted spellings for cancellation (`stopCancellation`). 
Pull request for docs update https://github.com/laravel/docs/pull/9647