### PR TITLE
[2.x] Prevent customer from logging out

### DIFF
--- a/resources/views/components/button.blade.php
+++ b/resources/views/components/button.blade.php
@@ -7,6 +7,7 @@ $custom = $checkout->getCustomData();
 <a
     href='#!'
     data-items='{!! json_encode($items) !!}'
+    data-allow-logout='false'
     @if ($customer) data-customer-id='{{ $customer->paddle_id }}' @endif
     @if ($custom) data-custom-data='{{ json_encode($custom) }}' @endif
     @if ($returnUrl = $checkout->getReturnUrl()) data-success-url='{{ $returnUrl }}' @endif


### PR DESCRIPTION
This prevents a customer from logging out during the checkout process. If this happens, Cashier cannot track the original customer anymore and thus cannot link subscriptions etc to them.

Fixes https://github.com/laravel/cashier-paddle/issues/257