### PR TITLE
Migrated from Paddle.Setup() to Paddle.Initialize()

### DIFF
--- a/resources/views/js.blade.php
+++ b/resources/views/js.blade.php
@@ -24,5 +24,5 @@ if (isset($seller['pwAuth']) && Auth::check() && $customer = Auth::user()->custo
 @endif
 
 <script type="text/javascript">
-    Paddle.Setup(@json($seller));
+    Paddle.Initialize(@json($seller));
 </script>


### PR DESCRIPTION
The current method `Paddle.Setup()` is marked as deprecated, modified the view to use the preferred `Paddle.Initialize()` method.
The docs states boths methods are functionally the same.

See: https://developer.paddle.com/paddlejs/methods/paddle-setup
