### PR TITLE
Handle empty name values for a customer

### DIFF
--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -45,6 +45,10 @@ trait ManagesCustomer
             $response = Cashier::api('POST', 'customers', $options)['data'];
         }
 
+        if (is_null($response['name'])) {
+            throw new LogicException("The Paddle customer [{$response['id']}] has no name. You may need to set the name of the customer in the Paddle dasbhboard.");
+        }
+
         if (Cashier::$customerModel::where('paddle_id', $response['id'])->exists()) {
             throw new LogicException("The Paddle customer [{$response['id']}] already exists in the database.");
         }

--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -45,17 +45,13 @@ trait ManagesCustomer
             $response = Cashier::api('POST', 'customers', $options)['data'];
         }
 
-        if (is_null($response['name'])) {
-            throw new LogicException("The Paddle customer [{$response['id']}] has no name. You may need to set the name of the customer in the Paddle dasbhboard.");
-        }
-
         if (Cashier::$customerModel::where('paddle_id', $response['id'])->exists()) {
             throw new LogicException("The Paddle customer [{$response['id']}] already exists in the database.");
         }
 
         $customer = $this->customer()->make();
         $customer->paddle_id = $response['id'];
-        $customer->name = $response['name'];
+        $customer->name = $response['name'] ?? '';
         $customer->email = $response['email'];
         $customer->trial_ends_at = $trialEndsAt;
         $customer->save();

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -74,7 +74,7 @@ class WebhookController extends Controller
         }
 
         $customer->update([
-            'name' => $data['name'],
+            'name' => $data['name'] ?? '',
             'email' => $data['email'],
         ]);
 


### PR DESCRIPTION
Gracefully throw an error for the case where there is no name set for the customer.

See https://github.com/laravel/cashier-paddle/issues/266.