### PR TITLE
Don't trim the request values from Paddle

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,8 @@
 <?php
 
+use Illuminate\Foundation\Http\Middleware\TrimStrings;
 use Illuminate\Support\Facades\Route;
 
-Route::post('webhook', 'WebhookController')->name('webhook');
+Route::post('webhook', 'WebhookController')
+    ->withoutMiddleware(TrimStrings::class)
+    ->name('webhook');


### PR DESCRIPTION
Paddle verifies the signature based on the input as they have it on their end. If Cashier receives strings that have been trimmed by the framework, the signature verification fails. The fields need to stay exactly as Paddle sends them.

Related issues: https://github.com/laravel/cashier-paddle/issues/120 https://github.com/laravel/cashier-paddle/issues/152  https://github.com/laravel/cashier-paddle/issues/173 https://github.com/laravel/cashier-paddle/pull/121

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
