### PR TITLE
Fix search of customers by email

### DIFF
--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -37,7 +37,7 @@ trait ManagesCustomer
         // Attempt to find the customer by email address first...
         $response = Cashier::api('GET', 'customers', [
             'status' => 'active,archived',
-            'search' => $options['email'],
+            'email'  => $options['email'],
         ])['data'][0] ?? null;
 
         // If we can't find the customer by email, we'll create them on Paddle...


### PR DESCRIPTION
According to the Paddle Documentation here:
https://developer.paddle.com/api-reference/customers/list-customers

If you want to search for an exact email match, you need to use the field `email`.

Right now it is using `search` which does a fuzzy search of id, name and so on. Which can return another customer than the one wanted. We noticed this bug in production.
