### PR TITLE
[1.x] Support Laravel 12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.4, '8.0', 8.1, 8.2, 8.3]
-        laravel: [8, 9, 10, 11]
+        php: [7.4, '8.0', 8.1, 8.2, 8.3, 8.4]
+        laravel: [8, 9, 10, 11, 12]
         exclude:
           - php: 7.4
             laravel: 9
@@ -25,18 +25,30 @@ jobs:
             laravel: 10
           - php: 7.4
             laravel: 11
+          - php: 7.4
+            laravel: 12
           - php: '8.0'
             laravel: 10
           - php: '8.0'
             laravel: 11
+          - php: '8.0'
+            laravel: 12
           - php: 8.1
             laravel: 11
+          - php: 8.1
+            laravel: 12
           - php: 8.2
             laravel: 8
           - php: 8.3
             laravel: 8
           - php: 8.3
             laravel: 9
+          - php: 8.4
+            laravel: 8
+          - php: 8.4
+            laravel: 9
+          - php: 8.4
+            laravel: 10
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 
@@ -55,8 +67,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-           composer require "illuminate/contracts=^${{ matrix.laravel }}" --no-update
-           composer update --prefer-dist --no-interaction --no-progress
+          composer update --prefer-dist --no-interaction --no-progress --with="illuminate/contracts:^${{ matrix.laravel }}"
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
         "ext-json": "*",
         "ext-openssl": "*",
         "guzzlehttp/guzzle": "^7.4.5",
-        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0",
-        "illuminate/database": "^8.0|^9.0|^10.0|^11.0",
-        "illuminate/http": "^8.0|^9.0|^10.0|^11.0",
-        "illuminate/routing": "^8.0|^9.0|^10.0|^11.0",
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
-        "illuminate/view": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/database": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/http": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/routing": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/view": "^8.0|^9.0|^10.0|^11.0|^12.0",
         "moneyphp/money": "^3.2|^4.0",
         "nesbot/carbon": "^2.0|^3.0",
         "spatie/url": "^1.3.5|^2.0",
@@ -36,9 +36,9 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
+        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0",
         "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^9.0|^10.4"
+        "phpunit/phpunit": "^9.0|^10.4|^11.5"
     },
     "suggest": {
         "ext-intl": "Allows for more locales besides the default \"en\" when formatting money values."


### PR DESCRIPTION
The migration from Paddle Classic to Paddle Billing has still not been finalised from Paddle (currently in early access). 

This PR adds Laravel 12 support for those of us stuck on Paddle Classic until then.

