### PR TITLE
fix(#298): correctly parse and send expression array to view

### DIFF
--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -94,7 +94,8 @@ class CashierServiceProvider extends ServiceProvider
     protected function bootDirectives()
     {
         Blade::directive('paddleJS', function ($expression) {
-            return "<?php echo view('cashier::js', ['nonce' => {$expression}['nonce'] ?? '']); ?>";
+            $expression = $expression ?: '[]';
+            return '<?php echo view("cashier::js", ["nonce" => ' . $expression . '["nonce"] ?? ""]); ?>';
         });
     }
 

--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -95,6 +95,7 @@ class CashierServiceProvider extends ServiceProvider
     {
         Blade::directive('paddleJS', function ($expression) {
             $expression = $expression ?: '[]';
+
             return '<?php echo view("cashier::js", ["nonce" => '.$expression.'["nonce"] ?? ""]); ?>';
         });
     }

--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -95,7 +95,7 @@ class CashierServiceProvider extends ServiceProvider
     {
         Blade::directive('paddleJS', function ($expression) {
             $expression = $expression ?: '[]';
-            return '<?php echo view("cashier::js", ["nonce" => ' . $expression . '["nonce"] ?? ""]); ?>';
+            return '<?php echo view("cashier::js", ["nonce" => '.$expression.'["nonce"] ?? ""]); ?>';
         });
     }
 


### PR DESCRIPTION
This fixes the issue reported in https://github.com/laravel/cashier-paddle/issues/298 by correctly parsing the value of `$expression`

This means that `@PaddleJS` can be used without providing an expression array, just as it was before version 2.6.0.