### PR TITLE
add `authToken()` method to Customer

### DIFF
--- a/src/Customer.php
+++ b/src/Customer.php
@@ -54,4 +54,14 @@ class Customer extends Model
     {
         return $this->trial_ends_at && $this->trial_ends_at->isPast();
     }
+
+    /**
+     * Generate a customer authentication token.
+     *
+     * @return string
+    */
+    public function authToken()
+    {
+        return Cashier::api('POST', "customers/{$this->paddle_id}/auth-token")->json('data.customer_auth_token');
+    }
 }

--- a/src/Customer.php
+++ b/src/Customer.php
@@ -59,7 +59,7 @@ class Customer extends Model
      * Generate a customer authentication token.
      *
      * @return string
-    */
+     */
     public function authToken()
     {
         return Cashier::api('POST', "customers/{$this->paddle_id}/auth-token")->json('data.customer_auth_token');


### PR DESCRIPTION
I added a method `authToken()` to the Customer model, that returns the customer auth token

This is required to allow a user to use saved payment methods

Usage:
```php
$customer_auth_token = $user->customer->authToken();
```

Docs:
https://developer.paddle.com/build/checkout/saved-payment-methods#preselect-payment-method-generate