### PR TITLE
Fix: Update existing customer in createAsCustomer

### DIFF
--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -15,6 +15,8 @@ trait ManagesCustomer
     public function createAsCustomer(array $options = [])
     {
         if ($customer = $this->customer) {
+            $customer->update($options);
+            
             return $customer;
         }
 


### PR DESCRIPTION
The `createAsCustomer` method did not update an existing customer's details if they were passed in the `$options` array. This caused issues when trying to update properties like `trial_ends_at` on a customer who already exists, as the call would silently fail.

**Example Scenario:**

1.  A user begins to purchase a paid plan but abandons the checkout. This action can create a customer in Paddle without an active subscription.
2.  Later, the same user tries to start a generic trial, which calls `$user->createAsCustomer(['trial_ends_at' => now()->addDays(7)])`.

**Before this change,** the method would find the existing customer but ignore the `trial_ends_at` option, so the trial would not be applied.

**After this change,** the existing customer is correctly updated with the new trial end date. This PR resolves the issue by passing the `$options` to the `update` method.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
