### PR TITLE
Make Checkout object Arrayable

### DIFF
--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -2,9 +2,11 @@
 
 namespace Laravel\Paddle;
 
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
 use LogicException;
 
-class Checkout
+class Checkout implements Arrayable, JsonSerializable
 {
     /**
      * The custom data for the checkout.
@@ -140,5 +142,15 @@ class Checkout
     public function getReturnUrl(): ?string
     {
         return $this->returnTo;
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return $this->options();
+    }
+
+    public function toArray()
+    {
+        return $this->options();
     }
 }

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -144,11 +144,19 @@ class Checkout implements Arrayable, JsonSerializable
         return $this->returnTo;
     }
 
+    /**
+     * Get the checkout's JSON serializable attributes.
+     */
     public function jsonSerialize(): mixed
     {
         return $this->options();
     }
 
+    /**
+     * Convert the checkout to its array representation.
+     *
+     * @return array
+     */
     public function toArray()
     {
         return $this->options();


### PR DESCRIPTION
This PR makes the Checkout object implement JsonSerializable and Arrayable so that it becomes a little bit more elegant to work with Checkout objects in combination with Inertia apps.

Before this PR, you would need to do something like:

```php
Route::get('/checkout', function () {
    return Inertia::render('Dashboard', [
        'checkout' => auth()->user()->checkout('pri_deluxe_album')
            ->returnTo(route('dashboard'))
            ->options() // <- explicitly pass in the "options" to the view
    ]);
});
```

Now you can simply pass the Checkout object, which feels a lot better and requires less internal object knowledge:

```php
Route::get('/checkout', function () {
    return Inertia::render('Dashboard', [
        'checkout' => auth()->user()->checkout('pri_deluxe_album')
            ->returnTo(route('dashboard'))
    ]);
});
```