### PR TITLE
Remove scheduled_change from subscription update options

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -633,6 +633,7 @@ class Subscription extends Model
         $response = $this->updatePaddleSubscription(array_merge($options, [
             'items' => $items,
             'proration_billing_mode' => $this->prorationBehavior,
+            'scheduled_change' => null,
         ]));
 
         $this->forceFill([


### PR DESCRIPTION
Remove any schedule changes before updating to prevent duplicate charges.
