### PR TITLE
Add Cashier Paddle Boost skill 

### DIFF
--- a/resources/boost/skills/cashier-paddle-development/SKILL.blade.php
+++ b/resources/boost/skills/cashier-paddle-development/SKILL.blade.php
@@ -63,12 +63,19 @@ class User extends Authenticatable
 }
 @endboostsnippet
 
-For a non-User model, register it in a service provider:
+If you bill a non-`User` model, add the `Billable` trait to that model as well:
 
 @boostsnippet("Custom Billable Model", "php")
-// In AppServiceProvider::boot()
-Cashier::useCustomerModel(Team::class);
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Paddle\Billable;
+
+class Team extends Model
+{
+    use Billable;
+}
 @endboostsnippet
+
+No extra Cashier registration call is required for additional billable models.
 
 Add `@paddleJS` to your layout so Paddle's JavaScript is loaded for the overlay checkout:
 
@@ -98,12 +105,11 @@ Route::get('/subscribe', function (Request $request) {
 </x-paddle-button>
 @endboostsnippet
 
-For named subscriptions, pass `subscription_type` in custom data so Cashier can set the local `type` column from the webhook. Without it, all subscriptions are stored as `'default'`.
+For named subscriptions, pass the desired type as the second argument to `subscribe()`. Cashier stores `custom_data.subscription_type` automatically from that value; if you omit it, the local type defaults to `'default'`.
 
-@boostsnippet("Named Subscription with Custom Data", "php")
+@boostsnippet("Named Subscription Checkout", "php")
 $checkout = $request->user()
     ->subscribe('pri_premium_monthly', 'premium')
-    ->customData(['subscription_type' => 'premium'])
     ->returnTo(route('dashboard'));
 @endboostsnippet
 
@@ -117,7 +123,7 @@ $checkout = $request->user()
 
 ## Common Pitfalls
 
-- `subscribed('premium')` checks the local `type` column, not the Paddle plan name. The `type` is populated from `custom_data.subscription_type` in the webhook payload. If `customData(['subscription_type' => 'premium'])` was not passed during checkout, all subscriptions are stored as `'default'`.
+- `subscribed('premium')` checks the local `type` column, not the Paddle plan name. Pass the desired type as the second argument to `subscribe()`. Cashier writes `custom_data.subscription_type` automatically, so if you attach extra custom data, do not overwrite that key.
 - A 419 response from the webhook endpoint means `paddle/*` is not excluded from CSRF middleware. All Paddle POST requests will be rejected until this is configured.
 - A 403 response means `PADDLE_WEBHOOK_SECRET` is wrong or missing. Signature verification will silently block all events.
 - `subscribed()` returns true immediately after calling `cancel()`. The subscription stays valid during the grace period. Use `onGracePeriod()` to distinguish canceled subscriptions that still have access.

--- a/resources/boost/skills/cashier-paddle-development/SKILL.blade.php
+++ b/resources/boost/skills/cashier-paddle-development/SKILL.blade.php
@@ -1,0 +1,128 @@
+---
+name: cashier-paddle-development
+description: "Handles Laravel Cashier Paddle integration including subscriptions, webhooks, Paddle Checkout, transactions, charges, refunds, trials, proration, pausing, and multiple subscription types. Triggered when a user mentions Cashier, Billable, paddle_id, subscribe(), checkout(), Paddle subscriptions, or billing. Also applies when setting up webhooks, debugging subscribed() returning false, handling grace periods, testing with CashierFake, or troubleshooting subscription sync issues."
+license: MIT
+metadata:
+  author: laravel
+---
+@php
+/** @var \Laravel\Boost\Install\GuidelineAssist $assist */
+@endphp
+
+# Cashier Paddle Development
+
+## When to Apply
+
+Activate this skill when:
+
+- Installing or configuring Laravel Cashier Paddle
+- Setting up subscriptions, trials, quantities, or plan swapping
+- Handling webhooks or subscription state sync issues
+- Working with Paddle Checkout, transactions, or one-time charges
+- Testing billing scenarios with CashierFake
+- Debugging `subscribed()` returning false or subscription type mismatches
+
+## Documentation
+
+Use `search-docs` for detailed Cashier Paddle patterns and documentation covering subscriptions, webhooks, Paddle Checkout, transactions, payment methods, and testing.
+
+For deeper guidance on specific topics, read the relevant reference file before implementing:
+
+- `references/subscriptions.md` covers subscription creation, status checks, swapping, pausing, trials, quantities, and multiple products
+- `references/webhooks.md` covers webhook setup, custom handlers, CSRF exclusion, and local development with reverse proxies
+- `references/testing.md` covers CashierFake, API response mocking, and feature test patterns for billing code
+
+## Basic Usage
+
+### Installation
+
+```bash
+{{ $assist->artisanCommand('vendor:publish --tag="cashier-migrations"') }}
+{{ $assist->artisanCommand('migrate') }}
+{{ $assist->artisanCommand('vendor:publish --tag="cashier-config"') }}
+```
+
+### Environment Variables
+
+```
+PADDLE_CLIENT_SIDE_TOKEN=your-client-side-token
+PADDLE_API_KEY=your-api-key
+PADDLE_WEBHOOK_SECRET=your-webhook-secret
+PADDLE_SANDBOX=true
+CASHIER_CURRENCY_LOCALE=en
+```
+
+### Billable Model
+
+@boostsnippet("Add Billable Trait", "php")
+use Laravel\Paddle\Billable;
+
+class User extends Authenticatable
+{
+    use Billable;
+}
+@endboostsnippet
+
+For a non-User model, register it in a service provider:
+
+@boostsnippet("Custom Billable Model", "php")
+// In AppServiceProvider::boot()
+Cashier::useCustomerModel(Team::class);
+@endboostsnippet
+
+Add `@paddleJS` to your layout so Paddle's JavaScript is loaded for the overlay checkout:
+
+@boostsnippet("Paddle JS Directive", "blade")
+<head>
+    @paddleJS
+</head>
+@endboostsnippet
+
+### Creating a Subscription
+
+Cashier Paddle uses a checkout-based flow. `subscribe()` returns a `Checkout` instance that is passed to a Blade component — there is no direct API call for subscription creation.
+
+@boostsnippet("Subscription Checkout Route", "php")
+Route::get('/subscribe', function (Request $request) {
+    $checkout = $request->user()
+        ->subscribe('pri_monthly', 'default')
+        ->returnTo(route('dashboard'));
+
+    return view('billing', ['checkout' => $checkout]);
+});
+@endboostsnippet
+
+@boostsnippet("Subscription Checkout Button", "blade")
+<x-paddle-button :checkout="$checkout" class="px-8 py-4">
+    Subscribe
+</x-paddle-button>
+@endboostsnippet
+
+For **named subscriptions** (e.g. a user can hold multiple subscription types), pass `subscription_type` as custom data. Cashier reads this from the webhook to set the local `type` column. Without it, every subscription defaults to `'default'`.
+
+@boostsnippet("Named Subscription with Custom Data", "php")
+$checkout = $request->user()
+    ->subscribe('pri_premium_monthly', 'premium')
+    ->customData(['subscription_type' => 'premium'])
+    ->returnTo(route('dashboard'));
+@endboostsnippet
+
+## Verification
+
+1. Run migrations and confirm the `customers`, `subscriptions`, `subscription_items`, and `transactions` tables exist
+2. Confirm `paddle/*` is excluded from CSRF protection and `PADDLE_WEBHOOK_SECRET` is set
+3. Enable the required webhook event types in Paddle Dashboard > Notifications: `subscription.created`, `subscription.updated`, `subscription.paused`, `subscription.canceled`, `transaction.completed`, `transaction.updated`, `customer.updated`
+4. Test webhook delivery using the Paddle Dashboard notification log — a 419 means CSRF is blocking, a 403 means the secret is wrong
+5. Confirm `$user->subscribed()` returns the expected value after a subscription is created
+
+## Common Pitfalls
+
+- `subscribed('premium')` returns false even though the user subscribed — the argument is the local subscription `type`, not the Paddle plan name. The `type` is set from `custom_data.subscription_type` in the webhook. If `customData(['subscription_type' => 'premium'])` was not passed during checkout, every subscription is stored as `'default'`.
+- Webhooks returning 419 — the `paddle/*` route is not excluded from CSRF middleware. Without this exclusion, all Paddle POST requests are rejected.
+- Webhooks returning 403 — `PADDLE_WEBHOOK_SECRET` is wrong or not set. Without a matching secret, signature verification fails silently and blocks all events.
+- `subscribed()` returns true after calling `cancel()` — expected. The subscription stays valid during the grace period. Use `onGracePeriod()` to distinguish.
+- `paused()` returns false even though pause was requested — if `paused_at` is set but in the future, the subscription is on a pause grace period. Use `onPausedGracePeriod()` to check.
+- Subscription active in Paddle but not in app — webhooks are not reaching the controller. Check Paddle's delivery log for HTTP status codes, confirm `subscription.created` is enabled in Notifications, and verify the customer record exists locally.
+- Cannot remove the last price from a multi-product subscription — swap to a single price or cancel instead.
+- Currency formatting broken for non-English locales — install the `ext-intl` PHP extension.
+- Always use `search-docs` for the latest Cashier Paddle documentation rather than relying on this skill alone.

--- a/resources/boost/skills/cashier-paddle-development/SKILL.blade.php
+++ b/resources/boost/skills/cashier-paddle-development/SKILL.blade.php
@@ -80,7 +80,7 @@ Add `@paddleJS` to your layout so Paddle's JavaScript is loaded for the overlay 
 
 ### Creating a Subscription
 
-Cashier Paddle uses a checkout-based flow. `subscribe()` returns a `Checkout` instance that is passed to a Blade component — there is no direct API call for subscription creation.
+Cashier Paddle uses a checkout-based flow. `subscribe()` returns a `Checkout` instance that is passed to a Blade component. There is no direct API call for subscription creation.
 
 @boostsnippet("Subscription Checkout Route", "php")
 Route::get('/subscribe', function (Request $request) {
@@ -98,7 +98,7 @@ Route::get('/subscribe', function (Request $request) {
 </x-paddle-button>
 @endboostsnippet
 
-For **named subscriptions** (e.g. a user can hold multiple subscription types), pass `subscription_type` as custom data. Cashier reads this from the webhook to set the local `type` column. Without it, every subscription defaults to `'default'`.
+For named subscriptions, pass `subscription_type` in custom data so Cashier can set the local `type` column from the webhook. Without it, all subscriptions are stored as `'default'`.
 
 @boostsnippet("Named Subscription with Custom Data", "php")
 $checkout = $request->user()
@@ -112,17 +112,17 @@ $checkout = $request->user()
 1. Run migrations and confirm the `customers`, `subscriptions`, `subscription_items`, and `transactions` tables exist
 2. Confirm `paddle/*` is excluded from CSRF protection and `PADDLE_WEBHOOK_SECRET` is set
 3. Enable the required webhook event types in Paddle Dashboard > Notifications: `subscription.created`, `subscription.updated`, `subscription.paused`, `subscription.canceled`, `transaction.completed`, `transaction.updated`, `customer.updated`
-4. Test webhook delivery using the Paddle Dashboard notification log — a 419 means CSRF is blocking, a 403 means the secret is wrong
+4. Test webhook delivery using the Paddle Dashboard notification log. A 419 response means CSRF is blocking. A 403 response means the secret is wrong.
 5. Confirm `$user->subscribed()` returns the expected value after a subscription is created
 
 ## Common Pitfalls
 
-- `subscribed('premium')` returns false even though the user subscribed — the argument is the local subscription `type`, not the Paddle plan name. The `type` is set from `custom_data.subscription_type` in the webhook. If `customData(['subscription_type' => 'premium'])` was not passed during checkout, every subscription is stored as `'default'`.
-- Webhooks returning 419 — the `paddle/*` route is not excluded from CSRF middleware. Without this exclusion, all Paddle POST requests are rejected.
-- Webhooks returning 403 — `PADDLE_WEBHOOK_SECRET` is wrong or not set. Without a matching secret, signature verification fails silently and blocks all events.
-- `subscribed()` returns true after calling `cancel()` — expected. The subscription stays valid during the grace period. Use `onGracePeriod()` to distinguish.
-- `paused()` returns false even though pause was requested — if `paused_at` is set but in the future, the subscription is on a pause grace period. Use `onPausedGracePeriod()` to check.
-- Subscription active in Paddle but not in app — webhooks are not reaching the controller. Check Paddle's delivery log for HTTP status codes, confirm `subscription.created` is enabled in Notifications, and verify the customer record exists locally.
-- Cannot remove the last price from a multi-product subscription — swap to a single price or cancel instead.
-- Currency formatting broken for non-English locales — install the `ext-intl` PHP extension.
+- `subscribed('premium')` checks the local `type` column, not the Paddle plan name. The `type` is populated from `custom_data.subscription_type` in the webhook payload. If `customData(['subscription_type' => 'premium'])` was not passed during checkout, all subscriptions are stored as `'default'`.
+- A 419 response from the webhook endpoint means `paddle/*` is not excluded from CSRF middleware. All Paddle POST requests will be rejected until this is configured.
+- A 403 response means `PADDLE_WEBHOOK_SECRET` is wrong or missing. Signature verification will silently block all events.
+- `subscribed()` returns true immediately after calling `cancel()`. The subscription stays valid during the grace period. Use `onGracePeriod()` to distinguish canceled subscriptions that still have access.
+- `paused()` returns false while a pause is scheduled but not yet in effect. If `paused_at` is in the future, use `onPausedGracePeriod()` instead.
+- A subscription active in Paddle but missing from the app means webhooks are not reaching the controller. Check Paddle's delivery log for HTTP status codes, confirm `subscription.created` is enabled in Notifications, and verify the customer record exists locally.
+- The last price on a multi-product subscription cannot be removed. Swap to a single price or cancel the subscription instead.
+- Currency formatting is broken for non-English locales if the `ext-intl` PHP extension is not installed.
 - Always use `search-docs` for the latest Cashier Paddle documentation rather than relying on this skill alone.

--- a/resources/boost/skills/cashier-paddle-development/references/subscriptions.md
+++ b/resources/boost/skills/cashier-paddle-development/references/subscriptions.md
@@ -9,7 +9,7 @@ Use `search-docs` for authoritative documentation on subscriptions.
 | `$user->subscribed('default')` | Active, trialing, or on grace period |
 | `->onTrial()` | Trial period active |
 | `->onGracePeriod()` | Canceled, billing period not yet ended |
-| `->canceled()` | `ends_at` is set (may still have access) |
+| `->canceled()` | Status is `canceled` |
 | `->recurring()` | Active and not on trial |
 | `->pastDue()` | Payment overdue |
 | `->paused()` | `paused_at` is in the past |
@@ -98,7 +98,6 @@ $user->subscription()->findItemOrFail('pri_addon');
 ```php
 // Create named subscriptions
 $checkout = $user->subscribe('pri_gym', 'gym')
-    ->customData(['subscription_type' => 'gym'])
     ->returnTo(route('home'));
 
 // Access them independently
@@ -106,6 +105,8 @@ $user->subscription('gym')->swap('pri_gym_yearly');
 $user->subscription('gym')->cancel();
 $user->subscribed('gym');
 ```
+
+Cashier sets `custom_data.subscription_type` from the second argument to `subscribe()` automatically. If you call `customData()` for other metadata, do not overwrite that key.
 
 ## Pausing
 

--- a/resources/boost/skills/cashier-paddle-development/references/subscriptions.md
+++ b/resources/boost/skills/cashier-paddle-development/references/subscriptions.md
@@ -1,0 +1,151 @@
+# Subscriptions Reference
+
+Use `search-docs` for authoritative documentation on subscriptions.
+
+## Status Methods
+
+| Method | Returns true when |
+|---|---|
+| `$user->subscribed('default')` | Active, trialing, or on grace period |
+| `->onTrial()` | Trial period active |
+| `->onGracePeriod()` | Canceled, billing period not yet ended |
+| `->canceled()` | `ends_at` is set (may still have access) |
+| `->recurring()` | Active and not on trial |
+| `->pastDue()` | Payment overdue |
+| `->paused()` | `paused_at` is in the past |
+| `->onPausedGracePeriod()` | `paused_at` is set but in the future |
+
+Check by price or product:
+
+```php
+$user->subscribedToPrice('pri_monthly', 'default');
+$user->subscribedToProduct('pro_premium', 'default');
+```
+
+Query scopes mirror all instance methods:
+
+```php
+Subscription::query()->active();
+Subscription::query()->onTrial();
+Subscription::query()->canceled();
+Subscription::query()->paused();
+// etc.
+```
+
+## Swapping Plans
+
+```php
+$user->subscription()->swap('pri_yearly');                  // with proration
+$user->subscription()->noProrate()->swap('pri_yearly');     // no proration
+$user->subscription()->swapAndInvoice('pri_yearly');        // swap + immediate invoice
+$user->subscription()->doNotBill()->swap('pri_yearly');     // swap, no charge
+```
+
+## Quantity
+
+```php
+$user->subscription()->incrementQuantity();
+$user->subscription()->decrementQuantity();
+$user->subscription()->updateQuantity(10);
+$user->subscription()->noProrate()->updateQuantity(10);
+
+// For a specific price in a multi-product subscription
+$user->subscription()->incrementQuantity(1, 'pri_addon');
+$user->subscription()->updateQuantity(3, 'pri_addon');
+```
+
+## Trials
+
+Trials with payment upfront are configured on the price in the Paddle dashboard. For generic trials (no payment required):
+
+```php
+$user->createAsCustomer(['trial_ends_at' => now()->addDays(14)]);
+
+$user->onTrial();         // true
+$user->onGenericTrial();  // true
+$user->trialEndsAt();     // Carbon instance
+```
+
+Extend or activate a trial:
+
+```php
+$user->subscription()->extendTrial(now()->addDays(7));
+$user->subscription()->activate(); // end trial immediately, begin billing
+```
+
+## Multiple Products on One Subscription
+
+```php
+// Subscribe to multiple prices
+$checkout = $user->subscribe(['pri_base', 'pri_addon']);
+
+// With quantities
+$checkout = $user->subscribe(['pri_base', 'pri_addon' => 5]);
+
+// Add a product by swapping (include all prices you want to keep)
+$user->subscription()->swap(['pri_base', 'pri_addon']);
+
+// Remove a product (must keep at least one price)
+$user->subscription()->swap(['pri_base']);
+
+// Check if a specific price is on the subscription
+$user->subscription()->hasPrice('pri_addon');
+$user->subscription()->findItemOrFail('pri_addon');
+```
+
+## Multiple Named Subscriptions
+
+```php
+// Create named subscriptions
+$checkout = $user->subscribe('pri_gym', 'gym')
+    ->customData(['subscription_type' => 'gym'])
+    ->returnTo(route('home'));
+
+// Access them independently
+$user->subscription('gym')->swap('pri_gym_yearly');
+$user->subscription('gym')->cancel();
+$user->subscribed('gym');
+```
+
+## Pausing
+
+```php
+$user->subscription()->pause();                              // at next billing cycle
+$user->subscription()->pauseNow();                           // immediately
+$user->subscription()->pauseUntil(now()->addMonth());
+$user->subscription()->pauseNowUntil(now()->addMonth());
+$user->subscription()->resume();
+```
+
+## Cancellation
+
+```php
+$user->subscription()->cancel();          // at end of billing period
+$user->subscription()->cancelNow();       // immediately
+$user->subscription()->stopCancelation(); // undo a scheduled cancel
+```
+
+## Single Charges on a Subscription
+
+```php
+$user->subscription()->charge('pri_addon');             // at next billing cycle
+$user->subscription()->chargeAndInvoice('pri_addon');   // immediately
+```
+
+## Payment Method Update
+
+```php
+return $user->subscription()->redirectToUpdatePaymentMethod();
+```
+
+## Past and Upcoming Payments
+
+```php
+$subscription = $user->subscription();
+
+$lastPayment = $subscription->lastPayment();
+$nextPayment = $subscription->nextPayment();
+
+// Display
+"Next payment: {$nextPayment->amount()} due on {$nextPayment->date()->format('d/m/Y')}";
+```

--- a/resources/boost/skills/cashier-paddle-development/references/testing.md
+++ b/resources/boost/skills/cashier-paddle-development/references/testing.md
@@ -1,0 +1,127 @@
+# Testing Reference
+
+Use `search-docs` for authoritative documentation on testing Cashier Paddle integrations.
+
+## CashierFake
+
+`Cashier::fake()` does two things at once: registers `Http::fake()` intercepts for Paddle API endpoints, and calls `Event::fake()` for all Cashier events. Call it once at the top of each test before any Cashier API interactions.
+
+```php
+use Laravel\Paddle\Cashier;
+
+public function test_user_can_subscribe(): void
+{
+    Cashier::fake();
+
+    // Seed subscription state that would normally arrive via webhook
+    $user = User::factory()->create();
+    $user->customer()->create(['paddle_id' => 'cus_test123']);
+
+    $user->subscriptions()->create([
+        'type'      => 'default',
+        'paddle_id' => 'sub_test123',
+        'status'    => 'active',
+    ])->items()->create([
+        'product_id' => 'pro_basic',
+        'price_id'   => 'pri_monthly',
+        'status'     => 'active',
+        'quantity'   => 1,
+    ]);
+
+    $this->assertTrue($user->subscribed());
+    $this->assertFalse($user->subscription()->onTrial());
+}
+```
+
+## Mocking API Responses
+
+When your code calls Paddle's API (e.g. `swap()`, `cancel()`, `updateQuantity()`), register a fake response before the call:
+
+```php
+Cashier::fake([
+    'subscriptions/sub_test123' => [
+        'data' => [
+            'id'     => 'sub_test123',
+            'status' => 'active',
+            'items'  => [
+                [
+                    'price'    => ['id' => 'pri_yearly', 'product_id' => 'pro_basic'],
+                    'status'   => 'active',
+                    'quantity' => 1,
+                ],
+            ],
+        ],
+    ],
+]);
+
+$subscription->swap('pri_yearly');
+```
+
+The endpoint key maps to the Paddle API URI. Use glob patterns when the ID is dynamic:
+
+```php
+Cashier::fake([
+    'subscriptions*' => ['data' => [...]],
+]);
+```
+
+The fluent `->response()` method wraps the data in a `['data' => ...]` envelope automatically:
+
+```php
+Cashier::fake()->response('subscriptions/sub_123', [
+    'id' => 'sub_123',
+    'status' => 'active',
+    'items' => [...],
+]);
+```
+
+Simulate an API error with `->error()`, which causes `Cashier::api()` to throw `PaddleException`:
+
+```php
+Cashier::fake()->error('subscriptions/sub_bad');
+```
+
+## Asserting Events
+
+```php
+Cashier::assertSubscriptionCreated();
+Cashier::assertSubscriptionUpdated();
+Cashier::assertSubscriptionCanceled();
+Cashier::assertSubscriptionPaused();
+Cashier::assertTransactionCompleted();
+Cashier::assertTransactionUpdated();
+Cashier::assertCustomerUpdated();
+Cashier::assertSubscriptionNotCreated();
+
+// With a callback to check specific attributes
+Cashier::assertSubscriptionCanceled(function ($event) {
+    return $event->subscription->paddle_id === 'sub_test123';
+});
+```
+
+## Simulating Webhooks
+
+To test code that reacts to Cashier webhook events, post a payload directly to the webhook route:
+
+```php
+$this->postJson('paddle/webhook', [
+    'event_type' => 'transaction.completed',
+    'data' => [
+        'id'          => 'txn_test',
+        'customer_id' => 'cus_test123',
+        'status'      => 'completed',
+        'custom_data' => ['order_id' => $order->id],
+        'details'     => ['totals' => ['total' => '1000', 'tax' => '100']],
+        'currency_code' => 'USD',
+        'billed_at'   => now()->toISOString(),
+    ],
+])->assertOk();
+```
+
+## Setup Notes
+
+- Cashier Paddle ships with `Cashier::fake()` as its primary test helper — there is no need to mock the HTTP client manually.
+- The `swap()`, `cancel()`, `pause()`, and `updateQuantity()` methods all call Paddle's API. Register fake responses for these endpoints or they will attempt real network calls.
+- `swap()` reads `$response['items']` to sync local subscription items via `syncSubscriptionItems()`. If the fake response omits items, `hasPrice()` will return false after the swap.
+- Calling `Cashier::fake()` multiple times in a single test resets the event fake. Call it once at the test start and register all endpoint responses up front, or use the fluent `->response()` method to add responses after the initial call.
+- Refer to `tests/Feature/` in the Cashier Paddle package source for integration test patterns covering subscriptions, webhooks, and transactions.

--- a/resources/boost/skills/cashier-paddle-development/references/testing.md
+++ b/resources/boost/skills/cashier-paddle-development/references/testing.md
@@ -101,10 +101,10 @@ Cashier::assertSubscriptionCanceled(function ($event) {
 
 ## Simulating Webhooks
 
-To test code that reacts to Cashier webhook events, post a payload directly to the webhook route:
+To test code that reacts to Cashier webhook events, post a payload directly to the webhook route. If your test environment sets `cashier.webhook_secret`, either unset it for the test or send a valid `Paddle-Signature` header.
 
 ```php
-$this->postJson('paddle/webhook', [
+$payload = [
     'event_type' => 'transaction.completed',
     'data' => [
         'id'          => 'txn_test',
@@ -115,7 +115,24 @@ $this->postJson('paddle/webhook', [
         'currency_code' => 'USD',
         'billed_at'   => now()->toISOString(),
     ],
-])->assertOk();
+];
+
+config()->set('cashier.webhook_secret', null);
+
+$this->postJson('paddle/webhook', $payload)->assertOk();
+```
+
+If you want to keep signature verification enabled, sign the exact JSON body you send:
+
+```php
+$payload = ['event_type' => 'transaction.completed', 'data' => [...]];
+$json = json_encode($payload, JSON_THROW_ON_ERROR);
+$timestamp = time();
+$signature = hash_hmac('sha256', "{$timestamp}:{$json}", config('cashier.webhook_secret'));
+
+$this->withHeader('Paddle-Signature', "ts={$timestamp};h1={$signature}")
+    ->call('POST', 'paddle/webhook', [], [], [], ['CONTENT_TYPE' => 'application/json'], $json)
+    ->assertOk();
 ```
 
 ## Setup Notes

--- a/resources/boost/skills/cashier-paddle-development/references/webhooks.md
+++ b/resources/boost/skills/cashier-paddle-development/references/webhooks.md
@@ -1,0 +1,148 @@
+# Webhooks Reference
+
+Use `search-docs` for authoritative documentation on webhooks.
+
+## Auto-Registered Route
+
+Cashier registers one route automatically (unless `Cashier::ignoreRoutes()` is called):
+
+- `POST /paddle/webhook` named `cashier.webhook`
+
+## CSRF Exclusion (Required)
+
+Without this, Paddle's POST requests receive a 419 response and are silently dropped.
+
+**Laravel 11+ (`bootstrap/app.php`):**
+
+```php
+->withMiddleware(function (Middleware $middleware): void {
+    $middleware->validateCsrfTokens(except: [
+        'paddle/*',
+    ]);
+})
+```
+
+**Laravel 10 (`app/Http/Middleware/VerifyCsrfToken.php`):**
+
+```php
+protected $except = [
+    'paddle/*',
+];
+```
+
+## Webhook Signature Verification
+
+`VerifyWebhookSignature` middleware is applied automatically when `PADDLE_WEBHOOK_SECRET` is set. If not set, verification is silently skipped — always configure it in production.
+
+## Required Webhook Event Types
+
+Enable these in Paddle Dashboard > Notifications:
+
+- `customer.updated`
+- `transaction.completed`
+- `transaction.updated`
+- `subscription.created`
+- `subscription.updated`
+- `subscription.paused`
+- `subscription.canceled`
+
+If `subscription.created` is missing, new subscriptions will never be recorded locally.
+
+## Local Development
+
+Use a reverse proxy to expose your local app to Paddle:
+
+```bash
+# Using Expose
+expose share http://your-app.test
+
+# Using Ngrok
+ngrok http 80
+```
+
+Set the forwarded URL as your webhook endpoint in the Paddle Sandbox Dashboard > Notifications.
+
+## Listening to Webhook Events
+
+React to billing events in your application using Laravel event listeners:
+
+```php
+use Laravel\Paddle\Events\TransactionCompleted;
+use Laravel\Paddle\Events\WebhookReceived;
+
+// Listen to a specific Cashier event
+Event::listen(TransactionCompleted::class, function (TransactionCompleted $event) {
+    $orderId = $event->payload['data']['custom_data']['order_id'] ?? null;
+    Order::findOrFail($orderId)->markCompleted();
+});
+
+// Listen to ALL webhooks before Cashier processes them (useful for logging)
+Event::listen(WebhookReceived::class, function (WebhookReceived $event) {
+    Log::info('Paddle webhook', ['type' => $event->payload['event_type']]);
+});
+```
+
+All available Cashier events:
+
+| Event | Dispatched after |
+|---|---|
+| `WebhookReceived` | Every incoming webhook, before processing |
+| `WebhookHandled` | After Cashier processes a known event |
+| `CustomerUpdated` | `customer.updated` |
+| `TransactionCompleted` | `transaction.completed` |
+| `TransactionUpdated` | `transaction.updated` |
+| `SubscriptionCreated` | `subscription.created` |
+| `SubscriptionUpdated` | `subscription.updated` |
+| `SubscriptionPaused` | `subscription.paused` |
+| `SubscriptionCanceled` | `subscription.canceled` |
+
+## Extending the Webhook Controller
+
+To override default processing or add custom behavior, extend `WebhookController`:
+
+```php
+use Laravel\Paddle\Http\Controllers\WebhookController as CashierController;
+
+class PaddleWebhookController extends CashierController
+{
+    protected function handleSubscriptionCreated(array $payload): void
+    {
+        parent::handleSubscriptionCreated($payload);
+
+        // Additional post-processing
+        $subscriptionId = $payload['data']['id'];
+        // ...
+    }
+}
+```
+
+Disable Cashier's auto-registered route and point to your controller:
+
+```php
+// In AppServiceProvider::boot()
+Cashier::ignoreRoutes();
+```
+
+```php
+// routes/web.php
+Route::post('paddle/webhook', [PaddleWebhookController::class, '__invoke']);
+```
+
+## Custom Webhook URL
+
+```env
+CASHIER_WEBHOOK=https://example.com/my-paddle-webhook-url
+```
+
+## Diagnosing Webhook Issues
+
+Check Paddle's delivery log in Dashboard > Notifications > your endpoint > Recent deliveries. Common HTTP response codes:
+
+| Code | Cause | Fix |
+|---|---|---|
+| 419 | CSRF blocking the request | Exclude `paddle/*` from CSRF |
+| 403 | Signature verification failed | Verify `PADDLE_WEBHOOK_SECRET` matches the dashboard |
+| 404 | Route not found | Check `php artisan route:list` for `paddle/webhook` |
+| 500 | Application exception | Check `storage/logs/laravel.log` |
+
+If webhooks arrive but subscription state is stale, check that the `customers` table has a row with `paddle_id` matching the `customer_id` in the payload — `handleSubscriptionCreated` exits early if `findBillable()` returns null.


### PR DESCRIPTION
Adds a Boost skill for Laravel Cashier Paddle to assist application developers integrating Paddle subscriptions into their Laravel apps.