### PR TITLE
Remove redundant "When to Apply" section from skill body

### DIFF
--- a/resources/boost/skills/cashier-paddle-development/SKILL.blade.php
+++ b/resources/boost/skills/cashier-paddle-development/SKILL.blade.php
@@ -11,17 +11,6 @@ metadata:
 
 # Cashier Paddle Development
 
-## When to Apply
-
-Activate this skill when:
-
-- Installing or configuring Laravel Cashier Paddle
-- Setting up subscriptions, trials, quantities, or plan swapping
-- Handling webhooks or subscription state sync issues
-- Working with Paddle Checkout, transactions, or one-time charges
-- Testing billing scenarios with CashierFake
-- Debugging `subscribed()` returning false or subscription type mismatches
-
 ## Documentation
 
 Use `search-docs` for detailed Cashier Paddle patterns and documentation covering subscriptions, webhooks, Paddle Checkout, transactions, payment methods, and testing.


### PR DESCRIPTION
## Summary

- Removes the `## When to Apply` section from the Cashier Paddle skill file
- This section was already fully covered by the skill's `description` frontmatter — removing it doesn't affect skill triggering behavior

See laravel/boost#669 for the corresponding change in the Boost monorepo.