### PR TITLE
Update Symfony deps versions to support v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "moneyphp/money": "^3.2|^4.0",
         "nesbot/carbon": "^2.67|^3.0",
         "spatie/url": "^1.3.5|^2.0",
-        "symfony/http-kernel": "^6.2|^7.0",
+        "symfony/http-kernel": "^6.2|^7.0|^8.0",
         "symfony/polyfill-intl-icu": "^1.22.1"
     },
     "require-dev": {


### PR DESCRIPTION
Updates Symfony versions to allow v8. without this , the installation fails on laravel 13 projects.