### PR TITLE
[2.x] Fix workflow YAML syntax — quote *.x branch pattern

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - *.x
+      - '*.x'
   pull_request:
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
## Summary

PR #307 (Laravel 13.x Compatibility, 2026-02-21) accidentally unquoted `'*.x'` to `*.x` in `.github/workflows/tests.yml`. In YAML, `*` is a reserved character (alias node indicator), causing GitHub Actions to reject the workflow file. **No tests have been running** on push or schedule for over 5 weeks.

### Fix

Re-quote `*.x` to `'*.x'` on line 7 of `tests.yml`.

### CI note

Tests currently show failures on this fork PR because cashier-paddle's test suite requires Paddle API secrets (`PADDLE_SELLER_ID`, `PADDLE_API_KEY`, `PADDLE_WEBHOOK_SECRET`, `PADDLE_TEST_PRICE`) which are not available to fork PRs due to GitHub's security restrictions. The tests will pass once merged to upstream where the secrets are configured.

### Impact

Once merged, the daily scheduled tests and push-triggered tests will start running again across the Laravel 10–13 matrix.