### PR TITLE
GitHub Actions hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   help-wanted:
-    uses: laravel/.github/.github/workflows/issues.yml@main
+    uses: laravel/.github/.github/workflows/issues.yml@dd86ce0a18475504e42fa809d7454c1cb1a88028 # main

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   uneditable:
-    uses: laravel/.github/.github/workflows/pull-requests.yml@main
+    uses: laravel/.github/.github/workflows/pull-requests.yml@dd86ce0a18475504e42fa809d7454c1cb1a88028 # main

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   tests:
-    uses: laravel/.github/.github/workflows/static-analysis.yml@main
+    uses: laravel/.github/.github/workflows/static-analysis.yml@dd86ce0a18475504e42fa809d7454c1cb1a88028 # main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-22.04
@@ -38,10 +41,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, bcmath

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -10,4 +10,4 @@ jobs:
   update:
     permissions:
       contents: write
-    uses: laravel/.github/.github/workflows/update-changelog.yml@main
+    uses: laravel/.github/.github/workflows/update-changelog.yml@dd86ce0a18475504e42fa809d7454c1cb1a88028 # main


### PR DESCRIPTION
We are doing 3 things across the organization:

1. Pinning GitHub Actions to full commit SHAs (instead of mutable tags/branches).
2. Tightening workflow `permissions:` to least-privilege (write scope only where a step needs it).
3. Adding a Dependabot config to keep the pinned actions updated.

This pull request is part of that work.