### PR TITLE
[2.x] Fix trial end date for cardless trials

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -284,33 +284,6 @@ class WebhookController extends Controller
     }
 
     /**
-     * Determine when the trial ends for the given subscription payload.
-     *
-     * Cardless trials never have a next billing date, since there's no payment method to
-     * charge, so the trial end is taken from the subscription items instead.
-     *
-     * @param  array  $data
-     * @return \Carbon\Carbon|null
-     */
-    protected function trialEndsAt(array $data)
-    {
-        if ($data['status'] !== Subscription::STATUS_TRIALING) {
-            return null;
-        }
-
-        if (isset($data['next_billed_at'])) {
-            return Carbon::parse($data['next_billed_at'], 'UTC');
-        }
-
-        $trialEndsAt = collect($data['items'] ?? [])
-            ->pluck('trial_dates.ends_at')
-            ->filter()
-            ->max();
-
-        return $trialEndsAt ? Carbon::parse($trialEndsAt, 'UTC') : null;
-    }
-
-    /**
      * Get the customer instance by its Paddle customer ID.
      *
      * @param  string  $customerId
@@ -374,5 +347,29 @@ class WebhookController extends Controller
     protected function transactionExists(string $transactionId)
     {
         return Cashier::$transactionModel::where('paddle_id', $transactionId)->count() > 0;
+    }
+
+    /**
+     * Determine when the trial ends for the given subscription payload.
+     *
+     * @param  array  $data
+     * @return \Carbon\Carbon|null
+     */
+    protected function trialEndsAt(array $data)
+    {
+        if ($data['status'] !== Subscription::STATUS_TRIALING) {
+            return null;
+        }
+
+        if (isset($data['next_billed_at'])) {
+            return Carbon::parse($data['next_billed_at'], 'UTC');
+        }
+
+        $trialEndsAt = collect($data['items'] ?? [])
+            ->pluck('trial_dates.ends_at')
+            ->filter()
+            ->max();
+
+        return $trialEndsAt ? Carbon::parse($trialEndsAt, 'UTC') : null;
     }
 }

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -160,9 +160,7 @@ class WebhookController extends Controller
             'type' => $data['custom_data']['subscription_type'] ?? Subscription::DEFAULT_TYPE,
             'paddle_id' => $data['id'],
             'status' => $data['status'],
-            'trial_ends_at' => $data['status'] === Subscription::STATUS_TRIALING
-                ? Carbon::parse($data['next_billed_at'], 'UTC')
-                : null,
+            'trial_ends_at' => $this->trialEndsAt($data),
         ]);
 
         foreach ($data['items'] as $item) {
@@ -195,11 +193,7 @@ class WebhookController extends Controller
 
         $subscription->status = $data['status'];
 
-        if ($data['status'] === Subscription::STATUS_TRIALING) {
-            $subscription->trial_ends_at = Carbon::parse($data['next_billed_at'], 'UTC');
-        } else {
-            $subscription->trial_ends_at = null;
-        }
+        $subscription->trial_ends_at = $this->trialEndsAt($data);
 
         if (isset($data['paused_at'])) {
             $subscription->paused_at = Carbon::parse($data['paused_at'], 'UTC');
@@ -287,6 +281,33 @@ class WebhookController extends Controller
         $subscription->save();
 
         SubscriptionCanceled::dispatch($subscription, $payload);
+    }
+
+    /**
+     * Determine when the trial ends for the given subscription payload.
+     *
+     * Cardless trials never have a next billing date, since there's no payment method to
+     * charge, so the trial end is taken from the subscription items instead.
+     *
+     * @param  array  $data
+     * @return \Carbon\Carbon|null
+     */
+    protected function trialEndsAt(array $data)
+    {
+        if ($data['status'] !== Subscription::STATUS_TRIALING) {
+            return null;
+        }
+
+        if (isset($data['next_billed_at'])) {
+            return Carbon::parse($data['next_billed_at'], 'UTC');
+        }
+
+        $trialEndsAt = collect($data['items'] ?? [])
+            ->pluck('trial_dates.ends_at')
+            ->filter()
+            ->max();
+
+        return $trialEndsAt ? Carbon::parse($trialEndsAt, 'UTC') : null;
     }
 
     /**

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -166,6 +166,143 @@ class WebhooksTest extends FeatureTestCase
         });
     }
 
+    public function test_it_can_handle_a_cardless_trial_subscription_created_event()
+    {
+        Cashier::fake();
+
+        $user = $this->createBillable();
+
+        $this->postJson('paddle/webhook', [
+            'event_type' => 'subscription_created',
+            'data' => [
+                'id' => 'sub_123456789',
+                'customer_id' => 'cus_123456789',
+                'status' => Subscription::STATUS_TRIALING,
+                'next_billed_at' => null,
+                'custom_data' => [
+                    'subscription_type' => 'main',
+                ],
+                'items' => [
+                    [
+                        'price' => [
+                            'id' => 'pri_123456789',
+                            'product_id' => 'pro_123456789',
+                        ],
+                        'status' => 'trialing',
+                        'quantity' => 1,
+                        'trial_dates' => [
+                            'starts_at' => now('UTC')->format('Y-m-d H:i:s'),
+                            'ends_at' => ($trialEndsAt = now('UTC')->addDays(14))->format('Y-m-d H:i:s'),
+                        ],
+                    ],
+                ],
+            ],
+        ])->assertOk();
+
+        $this->assertDatabaseHas('subscriptions', [
+            'billable_id' => $user->id,
+            'billable_type' => $user->getMorphClass(),
+            'type' => 'main',
+            'paddle_id' => 'sub_123456789',
+            'status' => Subscription::STATUS_TRIALING,
+            'trial_ends_at' => $trialEndsAt,
+        ]);
+    }
+
+    public function test_it_can_handle_a_cardless_trial_subscription_updated_event()
+    {
+        Cashier::fake();
+
+        $user = $this->createBillable('taylor');
+
+        $subscription = $user->subscriptions()->create([
+            'type' => 'main',
+            'paddle_id' => 'sub_123456789',
+            'status' => Subscription::STATUS_TRIALING,
+        ]);
+
+        $subscription->items()->create([
+            'subscription_id' => 1,
+            'product_id' => 'pro_123456789',
+            'price_id' => 'pri_123456789',
+            'status' => 'trialing',
+            'quantity' => 1,
+        ]);
+
+        $this->postJson('paddle/webhook', [
+            'event_type' => 'subscription_updated',
+            'data' => [
+                'id' => 'sub_123456789',
+                'customer_id' => 'cus_123456789',
+                'status' => Subscription::STATUS_TRIALING,
+                'next_billed_at' => null,
+                'custom_data' => [
+                    'subscription_type' => 'main',
+                ],
+                'items' => [
+                    [
+                        'price' => [
+                            'id' => 'pri_123456789',
+                            'product_id' => 'pro_123456789',
+                        ],
+                        'status' => 'trialing',
+                        'quantity' => 1,
+                        'trial_dates' => [
+                            'starts_at' => now('UTC')->format('Y-m-d H:i:s'),
+                            'ends_at' => ($trialEndsAt = now('UTC')->addDays(14))->format('Y-m-d H:i:s'),
+                        ],
+                    ],
+                ],
+            ],
+        ])->assertOk();
+
+        $this->assertDatabaseHas('subscriptions', [
+            'billable_id' => $user->id,
+            'billable_type' => $user->getMorphClass(),
+            'paddle_id' => 'sub_123456789',
+            'status' => Subscription::STATUS_TRIALING,
+            'trial_ends_at' => $trialEndsAt,
+        ]);
+    }
+
+    public function test_it_can_handle_a_card_required_trial_subscription_created_event()
+    {
+        Cashier::fake();
+
+        $user = $this->createBillable();
+
+        $this->postJson('paddle/webhook', [
+            'event_type' => 'subscription_created',
+            'data' => [
+                'id' => 'sub_123456789',
+                'customer_id' => 'cus_123456789',
+                'status' => Subscription::STATUS_TRIALING,
+                'next_billed_at' => ($trialEndsAt = now('UTC')->addDays(14))->format('Y-m-d H:i:s'),
+                'custom_data' => [
+                    'subscription_type' => 'main',
+                ],
+                'items' => [
+                    [
+                        'price' => [
+                            'id' => 'pri_123456789',
+                            'product_id' => 'pro_123456789',
+                        ],
+                        'status' => 'trialing',
+                        'quantity' => 1,
+                    ],
+                ],
+            ],
+        ])->assertOk();
+
+        $this->assertDatabaseHas('subscriptions', [
+            'billable_id' => $user->id,
+            'billable_type' => $user->getMorphClass(),
+            'paddle_id' => 'sub_123456789',
+            'status' => Subscription::STATUS_TRIALING,
+            'trial_ends_at' => $trialEndsAt,
+        ]);
+    }
+
     public function test_it_can_handle_a_duplicated_subscription_created_event()
     {
         Cashier::fake();


### PR DESCRIPTION
### The problem

Paddle's [cardless trials](https://developer.paddle.com/build/trials/cardless-trials) (currently in public early access) let customers start a trial without entering a card. A cardless trial is a normal subscription with `status: trialing`, but because there's no payment method to charge, Paddle sends **`next_billed_at: null`** — that null is Paddle's documented signal for "this is a cardless trial".

Both `handleSubscriptionCreated()` and `handleSubscriptionUpdated()` derive the trial end from that field:

```php
'trial_ends_at' => $data['status'] === Subscription::STATUS_TRIALING
    ? Carbon::parse($data['next_billed_at'], 'UTC')
    : null,
```

`Carbon::parse(null)` returns **now**, so a cardless trial is stored with `trial_ends_at` set to the moment the webhook arrived. A 4-month trial looks like it expired the instant it was created.

Here's a real `subscription.created` payload from the Paddle sandbox (trimmed):

```json
{
  "id": "sub_...",
  "status": "trialing",
  "next_billed_at": null,
  "scheduled_change": null,
  "items": [
    {
      "status": "trialing",
      "trial_dates": {
        "starts_at": "2026-07-31T13:32:00.313Z",
        "ends_at": "2026-11-30T13:32:00.313Z"
      }
    }
  ]
}
```

Paddle *does* report the real trial end — on the item's `trial_dates` — it just isn't where Cashier looks.

### Why this hasn't surfaced already

`Subscription::onTrial()` checks `status === 'trialing'` rather than the date, so `valid()`, `onTrial()` and access control all keep working. The corruption only shows up in anything that *reads* `trial_ends_at`: trial banners, "N days remaining", reminder scheduling, conversion prompts. Those silently show the wrong date rather than throwing, which makes it easy to miss.

### The fix

Both handlers now call a single `trialEndsAt()` helper. When `next_billed_at` is present it's used exactly as before; when it's null the trial end is taken from the items' `trial_dates`:

```php
protected function trialEndsAt(array $data)
{
    if ($data['status'] !== Subscription::STATUS_TRIALING) {
        return null;
    }

    if (isset($data['next_billed_at'])) {
        return Carbon::parse($data['next_billed_at'], 'UTC');
    }

    $trialEndsAt = collect($data['items'] ?? [])
        ->pluck('trial_dates.ends_at')
        ->filter()
        ->max();

    return $trialEndsAt ? Carbon::parse($trialEndsAt, 'UTC') : null;
}
```

This also removes the duplicated trial-date logic that previously lived in both handlers.

### Why it doesn't break existing behaviour

The change is strictly additive. `next_billed_at` is only consulted differently when it's `null` — a case that previously produced a wrong value and now produces the right one. Card-required trials, active subscriptions and every other status take exactly the same path they did before.

To make that explicit, one of the three added tests covers a **card-required** trial and asserts `trial_ends_at` still comes from `next_billed_at`. It passes both with and without this patch, so it functions as a regression guard rather than new coverage.

### Tests

Three tests added to `tests/Feature/WebhooksTest.php`:

- `test_it_can_handle_a_cardless_trial_subscription_created_event`
- `test_it_can_handle_a_cardless_trial_subscription_updated_event`
- `test_it_can_handle_a_card_required_trial_subscription_created_event`

The first two **fail on the current 2.x branch**, storing `trial_ends_at` as the current timestamp instead of the trial end. The third passes on both.

Full suite before and after this change produces an identical result on my machine (the two errors are environmental — a missing `intl` extension and `PricesTest` hitting the live API).

### Context

Found while building cardless-trial support in a production app, driving real webhooks from the Paddle sandbox into a local endpoint — so this is an observed failure with real payloads rather than a theoretical one.
