### PR TITLE
[2.x] Prevent stale transaction webhook downgrades

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -18,6 +18,7 @@ use Laravel\Paddle\Events\WebhookHandled;
 use Laravel\Paddle\Events\WebhookReceived;
 use Laravel\Paddle\Http\Middleware\VerifyWebhookSignature;
 use Laravel\Paddle\Subscription;
+use Laravel\Paddle\Transaction;
 use Symfony\Component\HttpFoundation\Response;
 
 class WebhookController extends Controller
@@ -124,6 +125,13 @@ class WebhookController extends Controller
         $data = $payload['data'];
 
         if (! $transaction = $this->findTransaction($data['id'])) {
+            return;
+        }
+
+        if (
+            $transaction->status === Transaction::STATUS_COMPLETED &&
+            $data['status'] !== Transaction::STATUS_COMPLETED
+        ) {
             return;
         }
 

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Support\Facades\Event;
 use Laravel\Paddle\Cashier;
 use Laravel\Paddle\Events\SubscriptionCanceled;
 use Laravel\Paddle\Events\SubscriptionCreated;
@@ -108,6 +109,63 @@ class WebhooksTest extends FeatureTestCase
         Cashier::assertTransactionUpdated(function (TransactionUpdated $event) {
             return $event->transaction->paddle_id === 'txn_123456789';
         });
+    }
+
+    public function test_an_older_paid_update_does_not_overwrite_a_completed_transaction()
+    {
+        Cashier::fake();
+
+        $this->createBillable();
+
+        $completedAt = now('UTC');
+        $billedAt = $completedAt->copy()->subMinute()->format('Y-m-d H:i:s');
+
+        $this->postJson('paddle/webhook', [
+            'event_type' => 'transaction.completed',
+            'occurred_at' => $completedAt->format('Y-m-d\TH:i:s.u\Z'),
+            'data' => [
+                'id' => 'txn_123456789',
+                'customer_id' => 'cus_123456789',
+                'status' => Transaction::STATUS_COMPLETED,
+                'subscription_id' => 'sub_123456789',
+                'invoice_number' => 'test-123456789',
+                'currency_code' => 'USD',
+                'details' => [
+                    'totals' => [
+                        'total' => '1500',
+                        'tax' => '300',
+                    ],
+                ],
+                'billed_at' => $billedAt,
+            ],
+        ])->assertOk();
+
+        $this->postJson('paddle/webhook', [
+            'event_type' => 'transaction.updated',
+            'occurred_at' => $completedAt->copy()->subSecond()->format('Y-m-d\TH:i:s.u\Z'),
+            'data' => [
+                'id' => 'txn_123456789',
+                'invoice_number' => null,
+                'status' => Transaction::STATUS_PAID,
+                'details' => [
+                    'totals' => [
+                        'total' => '1255',
+                        'tax' => '250',
+                    ],
+                ],
+                'billed_at' => $billedAt,
+            ],
+        ])->assertOk();
+
+        $this->assertDatabaseHas('transactions', [
+            'paddle_id' => 'txn_123456789',
+            'invoice_number' => 'test-123456789',
+            'status' => Transaction::STATUS_COMPLETED,
+            'total' => '1500',
+            'tax' => '300',
+        ]);
+
+        Event::assertNotDispatched(TransactionUpdated::class);
     }
 
     public function test_it_can_handle_a_subscription_created_event()


### PR DESCRIPTION
Fixes #310.

Paddle may deliver webhook notifications out of order. If
`transaction.completed` creates the final local record first, an older
`transaction.updated` payload in the temporary `paid` state can currently
overwrite the completed status, invoice number, and totals.

This keeps a stored completed transaction from regressing to a non-completed
state. Normal updates and completed-to-completed updates keep their existing
behavior, and the stale payload returns before dispatching a misleading
`TransactionUpdated` event. No schema or migration change is required.

I added a regression that delivers the reported payload order and verifies the
completed transaction remains intact.

Tests:

- `vendor/bin/phpunit tests/Feature/WebhooksTest.php` — 11 tests, 39 assertions
- `vendor/bin/phpunit --display-skipped` — 45 tests, 157 assertions; one
  credential-dependent price test skipped because `PADDLE_TEST_PRICE` is not
  configured locally
